### PR TITLE
Forward to "default" jobs if queue job name not found

### DIFF
--- a/sqs_workers/core.py
+++ b/sqs_workers/core.py
@@ -386,4 +386,8 @@ def group_messages(queue_name, messages):
 
 def get_job_name(message):
     attrs = message.message_attributes or {}
-    return (attrs.get('JobName') or {}).get('StringValue')
+    job_name = (attrs.get('JobName') or {}).get('StringValue')
+    if job_name is None:
+        return "default_fallback"
+    else:
+        return job_name


### PR DESCRIPTION
In case if we want to forward some payload (outside of this framework) to sqs queue and we can't specify job name it will be good to have some "default fallback" job.

Use case: 
if we want to send event from s3 to SQS, payload will look like:
{"Records": {"eventVersion": "2.1", ...}} - and there is no chance to specify job name. 

In current implementation there is kind of "bug like a feature" because `get_job_name` will return None if job name not found and you can specify None in `@sqs.processor(queue_name, None)` - but it looks ugly :(
