### PR TITLE
Add eager mode for SQS env

### DIFF
--- a/sqs_workers/async_task.py
+++ b/sqs_workers/async_task.py
@@ -35,15 +35,16 @@ class AsyncTask(object):
         """
         Run the task asynchronously.
         """
-        # In case when SQS env in debug mode, we want to run task synchronously.
-        if self.queue.env.debug_mode:
-            return self.run(*args, **kwargs)
-
         _content_type = kwargs.pop("_content_type", DEFAULT_CONTENT_TYPE)
         _delay_seconds = kwargs.pop("_delay_seconds", None)
         _deduplication_id = kwargs.pop("_deduplication_id", None)
         _group_id = kwargs.pop("_group_id", None)
         kwargs = adv_bind_arguments(self.processor, args, kwargs)
+
+        # In case when SQS env in debug mode, we want to run task synchronously.
+        if self.queue.env.debug_mode:
+            return self.run(*args, **kwargs)
+
         return self.queue.add_job(
             self.job_name,
             _content_type=_content_type,

--- a/sqs_workers/async_task.py
+++ b/sqs_workers/async_task.py
@@ -35,6 +35,10 @@ class AsyncTask(object):
         """
         Run the task asynchronously.
         """
+        # In case when SQS env in debug mode, we want to run task synchronously.
+        if self.queue.env.debug_mode:
+            return self.run(*args, **kwargs)
+
         _content_type = kwargs.pop("_content_type", DEFAULT_CONTENT_TYPE)
         _delay_seconds = kwargs.pop("_delay_seconds", None)
         _deduplication_id = kwargs.pop("_deduplication_id", None)

--- a/sqs_workers/async_task.py
+++ b/sqs_workers/async_task.py
@@ -41,8 +41,8 @@ class AsyncTask(object):
         _group_id = kwargs.pop("_group_id", None)
         kwargs = adv_bind_arguments(self.processor, args, kwargs)
 
-        # In case when SQS env in debug mode, we want to run task synchronously.
-        if self.queue.env.debug_mode:
+        # In case when SQS env in eager mode, we want to run task synchronously.
+        if self.queue.env.eager_mode:
             return self.run(*args, **kwargs)
 
         return self.queue.add_job(

--- a/sqs_workers/processors.py
+++ b/sqs_workers/processors.py
@@ -55,6 +55,8 @@ class Processor(object):
                 "Error while processing {queue_name}.{job_name}".format(**extra),
                 extra=extra,
             )
+            if self.queue.env.eager_mode:
+                raise
             return False
         else:
             return True

--- a/sqs_workers/queue.py
+++ b/sqs_workers/queue.py
@@ -228,6 +228,8 @@ class RawQueue(GenericQueue):
                 "Error while processing {queue_name}.{message_id}".format(**extra),
                 extra=extra,
             )
+            if self.queue.env.eager_mode:
+                raise
             return False
         else:
             return True

--- a/sqs_workers/sqs_env.py
+++ b/sqs_workers/sqs_env.py
@@ -34,6 +34,9 @@ class SQSEnv(object):
     sqs_resource = attr.ib(default=None)
     queues = attr.ib(init=False, factory=dict)  # type: dict[str, JobQueue]
 
+    # runs all tasks synchronously without SQS
+    debug_mode = attr.ib(default=False)  # type: bool
+
     def __attrs_post_init__(self):
         self.context = self.context_maker()
         self.sqs_client = self.session.client("sqs")

--- a/sqs_workers/sqs_env.py
+++ b/sqs_workers/sqs_env.py
@@ -35,7 +35,7 @@ class SQSEnv(object):
     queues = attr.ib(init=False, factory=dict)  # type: dict[str, JobQueue]
 
     # runs all tasks synchronously without SQS
-    debug_mode = attr.ib(default=False)  # type: bool
+    eager_mode = attr.ib(default=False)  # type: bool
 
     def __attrs_post_init__(self):
         self.context = self.context_maker()

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -11,3 +11,17 @@ def test_add_pickle_job(sqs, queue_name):
     result = sqs.queue(queue_name).process_batch(wait_seconds=0)
     assert result.succeeded_count() == 1
     assert messages == ["Homer"]
+
+
+def test_debug_mode(sqs, queue_name):
+    messages = []
+
+    sqs.debug_mode = True
+    _queue = sqs.queue(queue_name)
+
+    @_queue.processor("say_hello")
+    def say_hello(username=None):
+        messages.append(username)
+
+    say_hello.delay(username="Homer")
+    assert messages == ["Homer"]

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -13,10 +13,10 @@ def test_add_pickle_job(sqs, queue_name):
     assert messages == ["Homer"]
 
 
-def test_debug_mode(sqs, queue_name):
+def test_eager_mode(sqs, queue_name):
     messages = []
 
-    sqs.debug_mode = True
+    sqs.eager_mode = True
     _queue = sqs.queue(queue_name)
 
     @_queue.processor("say_hello")


### PR DESCRIPTION
When you faced with message: `UserWarning: Error while processing`  from SQS processor, it's hard to understand what the real problem is. Plus pdb will not work because SQS processor runs each queue in a separate process (when process_queues called).

It will be nice to have "debug_mode" which allows you to run processor function without sqs to see what problem happened inside this function. 

Maybe related: https://github.com/Doist/sqs-workers/issues/5