### PR TITLE
Add a way to add tasks in batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,27 @@ Is the same as
 send_email.delay(to='user@example.com', subject='Hello world', body='hello world')
 ```
 
+## Batching
+
+If you have many tasks to enqueue, it may be more efficient to use batching when adding them:
+
+```python
+# Classic ("explicit") API
+with queue.add_batch():
+    queue.add_job("send_email", to="user1@example.com", subject="Hello world", body="hello world")
+    queue.add_job("send_email", to="user2@example.com", subject="Hello world", body="hello world")
+
+# "Celery way"
+with send_email.batch():
+    send_email.delay(to="user1@example.com", subject="Hello world", body="hello world")
+    send_email.delay(to="user2@example.com", subject="Hello world", body="hello world")
+```
+
+When batching is enabled:
+- tasks are added to SQS by batches of 10, reducing the number of AWS operations
+- it is not possible to get the task `MessageId`, as it is not known until the batch is sent
+- care has to be taken about message size, as SQS limits both the individual message size and the maximum total payload size to 256 kB.
+
 ## Synchronous task execution
 
 In Celery, you can run any task synchronously if you just call it as a function with arguments. Our AsyncTask raises a RuntimeError for this case.

--- a/sqs_workers/__init__.py
+++ b/sqs_workers/__init__.py
@@ -4,6 +4,7 @@ from sqs_workers.backoff_policies import (  # noqa: F401
     ConstantBackoff,
     ExponentialBackoff,
 )
+from sqs_workers.exceptions import SQSError  # noaq: F401
 from sqs_workers.memory_sqs import MemorySession  # noqa: F401
 from sqs_workers.queue import JobQueue, RawQueue  # noqa: F401
 from sqs_workers.sqs_env import SQSEnv  # noqa: F401

--- a/sqs_workers/async_task.py
+++ b/sqs_workers/async_task.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Callable
 
 from sqs_workers.codecs import DEFAULT_CONTENT_TYPE
@@ -31,6 +32,14 @@ class AsyncTask(object):
         """
         kwargs = adv_bind_arguments(self.processor, args, kwargs)
         return self.processor(**kwargs)
+
+    @contextmanager
+    def batch(self):
+        """
+        Context manager to add jobs in batch.
+        """
+        with self.queue.add_batch():
+            yield
 
     def delay(self, *args, **kwargs):
         """

--- a/sqs_workers/backoff_policies.py
+++ b/sqs_workers/backoff_policies.py
@@ -2,7 +2,7 @@ import random
 
 
 class BackoffPolicy(object):
-    def get_visibility_timeout(self):
+    def get_visibility_timeout(self, message):
         raise NotImplementedError()
 
 

--- a/sqs_workers/exceptions.py
+++ b/sqs_workers/exceptions.py
@@ -1,0 +1,2 @@
+class SQSError(Exception):
+    pass

--- a/sqs_workers/memory_sqs.py
+++ b/sqs_workers/memory_sqs.py
@@ -126,6 +126,12 @@ class MemoryQueue(object):
         self.messages.append(message)
         return {"MessageId": message.message_id, "SequenceNumber": 0}
 
+    def send_messages(self, Entries):
+        res = []
+        for message in Entries:
+            res.append(self.send_message(**message))
+        return {"Successful": res, "Failed": []}
+
     def receive_messages(self, WaitTimeSeconds="0", MaxNumberOfMessages="10", **kwargs):
         """
         Helper function which returns at most max_messages from the

--- a/sqs_workers/queue.py
+++ b/sqs_workers/queue.py
@@ -180,7 +180,7 @@ class RawQueue(GenericQueue):
         self,
         message_body,  # type: str
         delay_seconds=0,  # type: int
-        deduplication_id=None,  # type: str
+        deduplication_id=None,  # type: Optional[str]
         group_id=DEFAULT_MESSAGE_GROUP_ID,  # type: str
     ):
         """
@@ -218,6 +218,7 @@ class RawQueue(GenericQueue):
             logger.warning(
                 "No processor set for {queue_name}".format(**extra), extra=extra
             )
+            return False
 
         logger.debug("Process {queue_name}.{message_id}".format(**extra), extra=extra)
 

--- a/sqs_workers/queue.py
+++ b/sqs_workers/queue.py
@@ -1,7 +1,9 @@
 import logging
+import uuid
 import warnings
+from contextlib import contextmanager
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 import attr
 
@@ -9,15 +11,22 @@ from sqs_workers import DEFAULT_BACKOFF, codecs
 from sqs_workers.async_task import AsyncTask
 from sqs_workers.backoff_policies import BackoffPolicy
 from sqs_workers.core import BatchProcessingResult, get_job_name
+from sqs_workers.exceptions import SQSError
 from sqs_workers.processors import DEFAULT_CONTEXT_VAR, Processor
 from sqs_workers.shutdown_policies import NEVER_SHUTDOWN
 
 DEFAULT_MESSAGE_GROUP_ID = "default"
+SEND_BATCH_SIZE = 10
 
 if TYPE_CHECKING:
     from sqs_workers import SQSEnv
 
 logger = logging.getLogger(__name__)
+
+
+class SQSBatchError(SQSError):
+    def __init__(self, errors):
+        self.errors = errors
 
 
 @attr.s
@@ -239,6 +248,9 @@ class JobQueue(GenericQueue):
 
     processors = attr.ib(factory=dict)  # type: Dict[str, Processor]
 
+    _batch_level = attr.ib(default=0, repr=False)  # type: int
+    _batched_messages = attr.ib(factory=list, repr=False)  # type: List[Dict]
+
     def processor(self, job_name, pass_context=False, context_var=DEFAULT_CONTEXT_VAR):
         """
         Decorator to assign processor to handle jobs with the name job_name
@@ -304,6 +316,59 @@ class JobQueue(GenericQueue):
         """
         return self.processors.get(job_name)
 
+    def open_add_batch(self):
+        """
+        Open an add batch.
+        """
+        self._batch_level += 1
+
+    def close_add_batch(self):
+        """
+        Close an add batch.
+        """
+        self._batch_level = max(0, self._batch_level - 1)
+        self._flush_batch_if_needed()
+
+    @contextmanager
+    def add_batch(self):
+        """
+        Context manager to add jobs in batch.
+
+        Inside this context manager, jobs won't be added to the queue immediately, but grouped by batches of 10.
+        Once open, new jobs won't be added immediately, but either
+        """
+        self.open_add_batch()
+        try:
+            yield
+        finally:
+            self.close_add_batch()
+
+    def _flush_batch_if_needed(self):
+        queue = self.get_queue()
+
+        # There should be at most 1 batch to send. But just in case, prepare to
+        # send more than that.
+        max_size = SEND_BATCH_SIZE if self._batch_level > 0 else 1
+        while len(self._batched_messages) >= max_size:
+            msgs = self._batched_messages[:SEND_BATCH_SIZE]
+            self._batched_messages = self._batched_messages[SEND_BATCH_SIZE:]
+
+            # Add Ids
+            msg_by_id = {}
+            for msg in msgs:
+                id_ = uuid.uuid4().hex
+                msg["Id"] = id_
+                msg_by_id[id_] = msg
+
+            res = queue.send_messages(Entries=msgs)
+
+            # Handle errors
+            if res.get("Failed", []):
+                errors = res["Failed"]
+                for error in errors:
+                    error["_message"] = msg_by_id[err["Id"]]
+                raise SQSBatchError(errors)
+
     def add_job(
         self,
         job_name,
@@ -364,8 +429,13 @@ class JobQueue(GenericQueue):
             kwargs["MessageDeduplicationId"] = str(deduplication_id)
         if group_id is not None:
             kwargs["MessageGroupId"] = str(group_id)
-        ret = queue.send_message(**kwargs)
-        return ret["MessageId"]
+
+        if self._batch_level > 0:
+            self._batched_messages.append(kwargs)
+            return None
+        else:
+            ret = queue.send_message(**kwargs)
+            return ret["MessageId"]
 
     def process_message(self, message):
         # type: (Any) -> bool


### PR DESCRIPTION
When a script has to enqueue a lot of tasks quickly, calling `send_message()` for each task is pretty inefficient.

This PR adds a way to batch those calls simply by wrapping them in a context manager. Behind the scenes, the messages are be sent to SQS in batches of 10 (or less for the last batch, when exiting the context manager).