### PR TITLE
Return the value of the processor

### DIFF
--- a/sqs_workers/processors.py
+++ b/sqs_workers/processors.py
@@ -94,4 +94,4 @@ def call_handler(fn, kwargs):
         # it may happen, if "fn" is not a function (but
         # a mock object, for example)
         handler_args, handler_kwargs = [], kwargs
-    fn(*handler_args, **handler_kwargs)
+    return fn(*handler_args, **handler_kwargs)


### PR DESCRIPTION
The call_handler function was not returning the actual value of the function being called.

I am working on a custom processor and it would be useful if the call_handler passed the return value of the function it calls back to the processor. 

