### PR TITLE
Modernize this a bit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '2.x', '3.7', '3.8', '3.9' ]
+        python-version: [ '3.8', '3.9', '3.10' ]
         session: ['memory', 'localstack']  # TODO: we don't test against production AWS
     timeout-minutes: 60
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,20 +1,26 @@
-name: test
-on: push
+name: Run test suite
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 jobs:
   test:
-    name: "python ${{ matrix.python-version }} with ${{ matrix.session }}"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: "Python ${{ matrix.python-version }} with ${{ matrix.session }}"
     strategy:
       matrix:
         python-version: [ '3.8', '3.9', '3.10' ]
         session: ['memory', 'localstack']  # TODO: we don't test against production AWS
-    timeout-minutes: 60
     steps:
       - name: Start Docker container with localstack
         if: matrix.session == 'localstack'
         run:  docker run -d -p 4566:9324 --rm softwaremill/elasticmq-native
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,7 +1,2 @@
 [settings]
-known_third_party=attr,boto3,localstack_client,pytest,setuptools
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88
+profile=black

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-known_third_party=attr,boto3,localstack_client,pytest,setuptools,werkzeug
+known_third_party=attr,boto3,localstack_client,pytest,setuptools
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-known_third_party=attr,boto3,localstack_client,past,pytest,setuptools,werkzeug
+known_third_party=attr,boto3,localstack_client,pytest,setuptools,werkzeug
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,8 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v4.2.0
     hooks:
-      - id: flake8
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: mixed-line-ending
@@ -13,23 +12,25 @@ repos:
       - id: check-case-conflict
       - id: debug-statements
 
-  - repo: https://github.com/python/black
-    rev: stable
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
     hooks:
       - id: black
 
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.1.1
-    hooks:
-      - id: seed-isort-config
-
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.770
+    rev: v0.942
     hooks:
       - id: mypy
+        additional_dependencies:
+          - types-attrs
+          - types-boto3
 
-  - repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21-2
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
     hooks:
       - id: isort
-        files: '.*\.py$'

--- a/README.md
+++ b/README.md
@@ -507,7 +507,3 @@ tox -- -k memory
 - Update the CHANGELOG
 - Commit the changes with a commit message "Version X.X.X"
 - Push the changes to GitHub and PyPI with a single command `make upload`
-
-## Why does it depend on werkzeug? 😱
-
-The only reason is [werkzeug.utils.validate_arguments](http://werkzeug.pocoo.org/docs/dev/utils/#werkzeug.utils.validate_arguments) which we love, and we are lazy enough to move it to this codebase.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.8
+python_version = 3.9
 follow_imports = silent
 scripts_are_modules = true
 namespace_packages = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.8
 follow_imports = silent
 scripts_are_modules = true
 namespace_packages = true

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+from typing import Any, Dict
 
 from setuptools import find_packages, setup
 
@@ -10,7 +11,7 @@ with open(os.path.join(here, "README.md"), "rt") as f:
     long_description = "\n" + f.read()
 
 
-version_mod = {}
+version_mod: Dict[str, Any] = {}
 with open(os.path.join(here, "sqs_workers", "__version__.py")) as f:
     exec(f.read(), version_mod)
 
@@ -23,7 +24,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Doist Developers",
     author_email="dev@doist.com",
-    python_requires=">=2.7",
+    python_requires=">=3.8",
     url="https://github.com/Doist/sqs-workers",
     packages=find_packages(exclude=["tests"]),
     install_requires=[
@@ -41,8 +42,6 @@ setup(
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
     packages=find_packages(exclude=["tests"]),
     install_requires=[
         "boto3",
-        "future",
         "pytest-runner",
         "attrs",
         "typing",

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     classifiers=[
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
+        "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         "pytest-runner",
         "attrs",
         "typing",
-        "werkzeug",
     ],
     include_package_data=True,
     license="MIT",

--- a/sqs_workers/__version__.py
+++ b/sqs_workers/__version__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 VERSION = (0, 5, 4)
 __version__ = ".".join(map(str, VERSION))
 

--- a/sqs_workers/async_task.py
+++ b/sqs_workers/async_task.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Callable
 
 from sqs_workers.codecs import DEFAULT_CONTENT_TYPE
-from sqs_workers.utils import adv_bind_arguments
+from sqs_workers.utils import bind_arguments
 
 if TYPE_CHECKING:
     from sqs_workers.queue import JobQueue
@@ -30,7 +30,7 @@ class AsyncTask(object):
         """
         Run the task synchronously.
         """
-        kwargs = adv_bind_arguments(self.processor, args, kwargs)
+        kwargs = bind_arguments(self.processor, args, kwargs)
         return self.processor(**kwargs)
 
     @contextmanager
@@ -49,7 +49,7 @@ class AsyncTask(object):
         _delay_seconds = kwargs.pop("_delay_seconds", None)
         _deduplication_id = kwargs.pop("_deduplication_id", None)
         _group_id = kwargs.pop("_group_id", None)
-        kwargs = adv_bind_arguments(self.processor, args, kwargs)
+        kwargs = bind_arguments(self.processor, args, kwargs)
         return self.queue.add_job(
             self.job_name,
             _content_type=_content_type,

--- a/sqs_workers/processors.py
+++ b/sqs_workers/processors.py
@@ -6,7 +6,7 @@ import attr
 
 from sqs_workers import codecs
 from sqs_workers.context import SQSContext
-from sqs_workers.utils import adv_validate_arguments
+from sqs_workers.utils import validate_arguments
 
 if TYPE_CHECKING:
     from sqs_workers.queue import GenericQueue
@@ -89,7 +89,7 @@ def get_job_context(job_message, codec):
 
 def call_handler(fn, kwargs):
     try:
-        handler_args, handler_kwargs = adv_validate_arguments(fn, [], kwargs)
+        handler_args, handler_kwargs = validate_arguments(fn, [], kwargs)
     except TypeError:
         # it may happen, if "fn" is not a function (but
         # a mock object, for example)

--- a/sqs_workers/utils.py
+++ b/sqs_workers/utils.py
@@ -1,7 +1,6 @@
 import importlib
 from typing import Any
 
-from past.types import unicode
 from werkzeug.utils import bind_arguments, validate_arguments
 
 
@@ -13,7 +12,7 @@ def adv_validate_arguments(callback, args, kwargs):
     :return: (args, kwargs) to pass to original function
     """
     bind_args = list(args)
-    bind_kwargs = {ensure_unicode(k): v for k, v in kwargs.items()}
+    bind_kwargs = {ensure_string(k): v for k, v in kwargs.items()}
     arguments, keyword_arguments = validate_arguments(callback, bind_args, bind_kwargs)
     return arguments, keyword_arguments
 
@@ -24,13 +23,12 @@ def adv_bind_arguments(callback, args, kwargs):
     passed args and kwargs
     """
     bind_args = list(args)
-    bind_kwargs = {ensure_unicode(k): v for k, v in kwargs.items()}
+    bind_kwargs = {ensure_string(k): v for k, v in kwargs.items()}
     keyword_arguments = bind_arguments(callback, bind_args, bind_kwargs)
     return keyword_arguments
 
 
-def string_to_object(string):
-    # type: (unicode) -> Any
+def string_to_object(string: str) -> Any:
     """
     Convert full path string representation of the object to object itself.
     """
@@ -62,13 +60,11 @@ def instantiate_from_dict(options, maker_key="maker", **extra_init_kwargs):
     return string_to_object(classname_value)(**init_kwargs)
 
 
-def ensure_unicode(obj, encoding="utf-8", errors="strict"):
-    # type: (Any, unicode, unicode) -> unicode
-    """Make sure an object is converted to a proper Unicode representation."""
-    if isinstance(obj, unicode):
-        uobj = obj
+def ensure_string(obj: Any, encoding="utf-8", errors="strict") -> str:
+    """Make sure an object is converted to a proper string representation."""
+    if isinstance(obj, str):
+        return obj
     elif isinstance(obj, bytes):
-        uobj = obj.decode(encoding, errors)
+        return obj.decode(encoding, errors)
     else:
-        uobj = unicode(obj)
-    return uobj
+        return str(obj)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,11 @@
 from textwrap import TextWrapper
 
 from sqs_workers.utils import (
-    adv_bind_arguments,
-    adv_validate_arguments,
+    bind_arguments,
     instantiate_from_dict,
     instantiate_from_string,
     string_to_object,
+    validate_arguments,
 )
 
 
@@ -27,18 +27,18 @@ def test_instantiate_from_string():
     assert w.width == 80
 
 
-def test_adv_bind_arguments_converts_to_unicode():
+def test_bind_arguments_converts_to_unicode():
     def foo(a, b):
         pass
 
-    kwargs = adv_bind_arguments(foo, [], {b"a": 1, b"b": 2})
+    kwargs = bind_arguments(foo, [], {b"a": 1, b"b": 2})
     assert kwargs == {"a": 1, "b": 2}
 
 
-def test_adv_validate_arguments_converts_to_unicode():
+def test_validate_arguments_converts_to_unicode():
     def foo(a, b):
         pass
 
-    args, kwargs = adv_validate_arguments(foo, [], {b"a": 1, b"b": 2})
+    args, kwargs = validate_arguments(foo, [], {b"a": 1, b"b": 2})
     assert args == (1, 2)
     assert kwargs == {}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py37,py38
+envlist = py38,py39,py310
 
 [testenv]
 deps =


### PR DESCRIPTION
Most important changes:
- drop support for Python < 3.8
- drop the dependency on Werkzeug as it's not needed anymore (and doesn't even work with recent versions of Werkzeug).

This also fixes #20.