### PR TITLE
Restore previous behavior for validate_arguments

### DIFF
--- a/sqs_workers/utils.py
+++ b/sqs_workers/utils.py
@@ -1,17 +1,70 @@
 import importlib
+import logging
 from inspect import Signature
 from typing import Any
 
+logger = logging.getLogger(__name__)
 
-def _bind_args(callback, args, kwargs):
+
+def _bind_args(callback, args, kwargs, drop_extra):
     sig = Signature.from_callable(callback)
     bind_args = list(args)
     bind_kwargs = {ensure_string(k): v for k, v in kwargs.items()}
+
+    if drop_extra:
+        # Compatibility with Werkzeug's `drop_extra`: if true, we drop extra
+        # positional and keyword arguments.
+        # This implementation is not perfect, but should be good enough for most
+        # real-world use cases.
+        extra_args, extra_kwargs = [], {}
+
+        # - Is there a *args argument?
+        if not any(
+            param.kind == param.VAR_POSITIONAL for param in sig.parameters.values()
+        ):
+            # No: drop extra positional arguments
+            all_pos = [
+                param.name
+                for param in sig.parameters.values()
+                if param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD)
+            ]
+            nb_pos = len(all_pos)
+            bind_args, extra_args = bind_args[:nb_pos], bind_args[nb_pos:]
+
+        # - Is there a **kwargs argument?
+        if not any(
+            param.kind == param.VAR_KEYWORD for param in sig.parameters.values()
+        ):
+            # No: drop extra keyword arguments
+            all_kw = {
+                param.name
+                for param in sig.parameters.values()
+                if param.kind in (param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY)
+            }
+            new_bind_kwargs = {}
+            for key, value in bind_kwargs.items():
+                if key in all_kw:
+                    new_bind_kwargs[key] = value
+                else:
+                    extra_kwargs[key] = value
+            bind_kwargs = new_bind_kwargs
+
+        if extra_args or extra_kwargs:
+            logger.debug(
+                "Dropped %d extra positional arguments and %d extra keyword arguments",
+                len(extra_args),
+                len(extra_kwargs),
+                extra={
+                    "extra_args": extra_args,
+                    "extra_kwargs": extra_kwargs,
+                },
+            )
+
     bound_args = sig.bind(*bind_args, **bind_kwargs)
     return bound_args
 
 
-def validate_arguments(callback, args, kwargs):
+def validate_arguments(callback, args, kwargs, drop_extra=True):
     """Checks if the function accepts the provided arguments and keyword
     arguments. Returns a new `(args, kwargs)` tuple that can be passed to the
     function without causing a TypeError due to an incompatible signature.
@@ -21,7 +74,7 @@ def validate_arguments(callback, args, kwargs):
     Similar to Werkzeug's old `validate_arguments` function, but doesn't modify
     passed args and kwargs.
     """
-    bound_args = _bind_args(callback, args, kwargs)
+    bound_args = _bind_args(callback, args, kwargs, drop_extra)
     return (bound_args.args, bound_args.kwargs)
 
 
@@ -32,7 +85,7 @@ def bind_arguments(callback, args, kwargs):
     Similar to Werkzeug's old `bind_arguments` function, but doesn't modify
     passed args and kwargs.
     """
-    bound_args = _bind_args(callback, args, kwargs)
+    bound_args = _bind_args(callback, args, kwargs, False)
     return bound_args.arguments
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
 from textwrap import TextWrapper
 
+import pytest
+
 from sqs_workers.utils import (
     bind_arguments,
     instantiate_from_dict,
@@ -42,3 +44,62 @@ def test_validate_arguments_converts_to_unicode():
     args, kwargs = validate_arguments(foo, [], {b"a": 1, b"b": 2})
     assert args == (1, 2)
     assert kwargs == {}
+
+
+def test_validate_arguments_drops_extra():
+    def foo(a, /, b, c, *, d):
+        pass
+
+    # Nothing dropped
+    args, kwargs = validate_arguments(foo, (1, 2), {"c": 3, "d": 4})
+    assert args == (1, 2, 3)
+    assert kwargs == {"d": 4}
+
+    # Extra positional argument dropped
+    args, kwargs = validate_arguments(foo, (1, 2, 3, 4), {"d": 5})
+    assert args == (1, 2, 3)
+    assert kwargs == {"d": 5}
+
+    # Extra keyword arguments dropped
+    args, kwargs = validate_arguments(
+        foo, (1,), {"a": -1, "b": 2, "c": 3, "foo": 4, "d": 5, "e": 6}
+    )
+    assert args == (1, 2, 3)
+    assert kwargs == {"d": 5}
+
+
+def test_bind_arguments_raises_on_extra():
+    def foo(a, /, b, c, *, d):
+        pass
+
+    # No error
+    args = bind_arguments(foo, (1, 2), {"c": 3, "d": 4})
+    assert args == {"a": 1, "b": 2, "c": 3, "d": 4}
+
+    # Too many positional arguments
+    with pytest.raises(TypeError):
+        bind_arguments(foo, (1, 2, 3, 4), {"d": 5})
+
+    # Unexpected keyword arguments
+    with pytest.raises(TypeError):
+        bind_arguments(foo, (1,), {"a": -1, "b": 2, "c": 3, "d": 4})
+    with pytest.raises(TypeError):
+        bind_arguments(
+            foo,
+            (1, 2),
+            {
+                "b": -1,
+                "c": 3,
+                "d": 4,
+            },
+        )
+    with pytest.raises(TypeError):
+        bind_arguments(
+            foo,
+            (1, 2),
+            {
+                "foo": 42,
+                "c": 3,
+                "d": 4,
+            },
+        )


### PR DESCRIPTION
The Werkzeug version silently dropped extra arguments by default. This commit
restores this behavior, to avoid backward incompatibility.