### PR TITLE
Support Batch Reading of Messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# PyCharm
+.idea/

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,9 @@
-## [0.6.0] - 2022-08-25
+## [Unreleased]
 
-- Added ability to configure a queue to send batches of messages
-  to a handling function rather than processing them individually
+### Added
+
+- Ability to configure a queue to send batches of messages to a
+  handling function rather than processing them individually
 
 ## [0.5.6] - 2022-05-10
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 
 - Using `%s` string interpolation for logging, easier for tools
   like Sentry / DataDog to group similar messages when parsing
+- Using type annotations over type comments now Python 2.7 support has been dropped
 
 ## [0.5.6] - 2022-05-10
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+## [0.6.0] - 2022-08-25
+
+- Added ability to configure a queue to send batches of messages
+  to a handling function rather than processing them individually
+
 ## [0.5.6] - 2022-05-10
 
 ### Fixed

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,12 @@
 
 - Ability to configure a queue to send batches of messages to a
   handling function rather than processing them individually
+- Contributing file to guide submitting PRs
+
+### Changed
+
+- Using `%s` string interpolation for logging, easier for tools
+  like Sentry / DataDog to group similar messages when parsing
 
 ## [0.5.6] - 2022-05-10
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+Thanks for helping us make SQS Worker better.
+
+Please feel free to [report any issue](https://github.com/Doist/sqs-workers/issues/new/choose) you may have.
+
+**Working on your first Pull Request?** You can learn how from this _free_
+series [How to Contribute to an Open Source Project on GitHub][egghead]
+
+If you want to contribute with code, please open a Pull Request. A few things to keep in mind:
+
+- The sqs-workers project is released under the [MIT license](./LICENSE)
+- Please use [pre-commit](https://pre-commit.com/) to ensure some formatting rules and basic consistency checks are applied before each Git commit
+- Please add tests for your changes!
+- Please document any changes using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention
+  - Changes in a PR should be documented under an `[Unreleased]` version
+  - We'll bump the version number and update the changelog in a separate PR when publishing

--- a/README.md
+++ b/README.md
@@ -118,11 +118,15 @@ you can use the `batch_processor` decorator.
 The underlying function is expected to have a single parameter which will receive the list of messages.
 
 ```python
-from sqs_workers import SQSEnv
+from sqs_workers import SQSEnv, create_standard_queue
 
 sqs = SQSEnv()
 
-@sqs.batch_processor("send_email", batch_size=10)
+create_standard_queue(sqs, "emails")
+
+queue = sqs.queue("emails")
+
+@queue.batch_processor("send_email", batch_size=10)
 def send_email(messages: list):
     for email in messages:
         print(f"Sending email {email.subject} to {email.to}")

--- a/README.md
+++ b/README.md
@@ -113,26 +113,30 @@ When batching is enabled:
 ## Batch Reads
 
 If you wish to consume and process batches of messages from a queue at once (say to speed up ingestion)
-you can use the `batch_processor` decorator.
+you can set the `batching_policy` at queue level.
 
 The underlying function is expected to have a single parameter which will receive the list of messages.
 
 ```python
+from sqs_workers.batching import BatchMessages
 from sqs_workers import SQSEnv, create_standard_queue
 
 sqs = SQSEnv()
 
 create_standard_queue(sqs, "emails")
 
-queue = sqs.queue("emails")
+queue = sqs.queue("emails", batching_policy=BatchMessages(batch_size=10))
 
-@queue.batch_processor("send_email", batch_size=10)
+@queue.processor("send_email")
 def send_email(messages: list):
     for email in messages:
         print(f"Sending email {email['subject']} to {email['to']}")
 ```
 
-This function will receive up to 10 messages at once based on how many are available on the queue being consumed.
+This function will receive up to 10 messages at once based on:
+
+* How many are available on the queue being consumed
+* How many of those messages on the `emails` queue are for the `send_email` job
 
 ## Synchronous task execution
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ queue = sqs.queue("emails")
 @queue.batch_processor("send_email", batch_size=10)
 def send_email(messages: list):
     for email in messages:
-        print(f"Sending email {email.subject} to {email.to}")
+        print(f"Sending email {email['subject']} to {email['to']}")
 ```
 
 This function will receive up to 10 messages at once based on how many are available on the queue being consumed.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Is the same as
 send_email.delay(to='user@example.com', subject='Hello world', body='hello world')
 ```
 
-## Batching
+## Batch Writes
 
 If you have many tasks to enqueue, it may be more efficient to use batching when adding them:
 
@@ -109,6 +109,24 @@ When batching is enabled:
 - tasks are added to SQS by batches of 10, reducing the number of AWS operations
 - it is not possible to get the task `MessageId`, as it is not known until the batch is sent
 - care has to be taken about message size, as SQS limits both the individual message size and the maximum total payload size to 256 kB.
+
+## Batch Reads
+
+If you wish to consume and process batches of messages from a queue at once (say to speed up ingestion)
+you can use the `batch_processor` decorator.
+
+```python
+from sqs_workers import SQSEnv
+
+sqs = SQSEnv()
+
+@sqs.batch_processor("send_email", batch_size=10)
+def send_email(emails: list):
+    for email in emails:
+        print(f"Sending email {email.subject} to {email.to}")
+```
+
+This function will receive up to 10 messages at once based on how many are available on the queue being consumed.
 
 ## Synchronous task execution
 

--- a/README.md
+++ b/README.md
@@ -455,17 +455,9 @@ Please note that MemorySession has some serious limitations, and may not fit wel
 
 ## Contributing
 
-Any help is welcome!
+Please see our guide [here](./CONTRIBUTING.md)
 
-Please feel free to [report any issue](https://github.com/Doist/sqs-workers/issues/new/choose) you may have.
-
-If you want to contribute with code, please open a Pull Request. A few things to keep in mind:
-
-- sqs-workers is released under the [MIT license](./LICENSE)
-- please use [pre-commit](https://pre-commit.com/) to ensure some formatting rules and basic consistency checks are applied before each Git commit
-- please add tests for your changes!
-
-### Testing
+## Testing
 
 We use pytest to run unittests, and tox to run them for all supported Python versions.
 

--- a/README.md
+++ b/README.md
@@ -115,14 +115,16 @@ When batching is enabled:
 If you wish to consume and process batches of messages from a queue at once (say to speed up ingestion)
 you can use the `batch_processor` decorator.
 
+The underlying function is expected to have a single parameter which will receive the list of messages.
+
 ```python
 from sqs_workers import SQSEnv
 
 sqs = SQSEnv()
 
 @sqs.batch_processor("send_email", batch_size=10)
-def send_email(emails: list):
-    for email in emails:
+def send_email(messages: list):
+    for email in messages:
         print(f"Sending email {email.subject} to {email.to}")
 ```
 

--- a/sqs_workers/__version__.py
+++ b/sqs_workers/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 5, 6)
+VERSION = (0, 6, 0)
 __version__ = ".".join(map(str, VERSION))
 
 if __name__ == "__main__":

--- a/sqs_workers/__version__.py
+++ b/sqs_workers/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 6, 0)
+VERSION = (0, 5, 6)
 __version__ = ".".join(map(str, VERSION))
 
 if __name__ == "__main__":

--- a/sqs_workers/async_task.py
+++ b/sqs_workers/async_task.py
@@ -52,7 +52,8 @@ class AsyncTask(object):
         _delay_seconds = kwargs.pop("_delay_seconds", None)
         _deduplication_id = kwargs.pop("_deduplication_id", None)
         _group_id = kwargs.pop("_group_id", None)
-        kwargs = bind_arguments(self.processor, args, kwargs)
+        if not self.queue.batching_policy.batching_enabled:
+            kwargs = bind_arguments(self.processor, args, kwargs)
         return self.queue.add_job(
             self.job_name,
             _content_type=_content_type,

--- a/sqs_workers/async_task.py
+++ b/sqs_workers/async_task.py
@@ -30,8 +30,11 @@ class AsyncTask(object):
         """
         Run the task synchronously.
         """
-        kwargs = bind_arguments(self.processor, args, kwargs)
-        return self.processor(**kwargs)
+        if self.queue.batching_policy.batching_enabled:
+            return self.processor([kwargs])
+        else:
+            kwargs = bind_arguments(self.processor, args, kwargs)
+            return self.processor(**kwargs)
 
     @contextmanager
     def batch(self):

--- a/sqs_workers/async_task.py
+++ b/sqs_workers/async_task.py
@@ -9,8 +9,7 @@ if TYPE_CHECKING:
 
 
 class AsyncTask(object):
-    def __init__(self, queue, job_name, processor):
-        # type: (JobQueue, str, Callable) -> None
+    def __init__(self, queue: "JobQueue", job_name: str, processor: Callable):
         self.queue = queue
         self.job_name = job_name
         self.processor = processor

--- a/sqs_workers/batching.py
+++ b/sqs_workers/batching.py
@@ -3,25 +3,30 @@ from abc import ABC, abstractmethod
 
 class BatchingConfiguration(ABC):
     """
-    Abstract class defining the contract for configuring whether
-    a processor receives messages 1 by 1, or processes them in batch.
+    Defining the contract for configuring whether a processor sends
+    messages 1 by 1 to a call handler, or as a list of messages.
     """
 
     @property
     @abstractmethod
     def batching_enabled(self) -> bool:
-        """If false, process messages 1 by 1, otherwise process in batch"""
+        """
+        If false, messages are sent 1 by 1 to the call handler
+        If true, messages are sent as a list to the call handler
+        """
         ...
 
     @property
     @abstractmethod
     def batch_size(self) -> int:
-        """Number of messages to process at once if batching_enabled"""
+        """
+        Number of messages to process at once if batching_enabled
+        """
         ...
 
 
 class NoBatching(BatchingConfiguration):
-    """Configures the processor to process each message 1 by 1"""
+    """Configures the processor to send messages 1 by 1 to the call handler"""
 
     @property
     def batching_enabled(self) -> bool:
@@ -33,7 +38,7 @@ class NoBatching(BatchingConfiguration):
 
 
 class BatchMessages(BatchingConfiguration):
-    """Configures the processor to process the messages in batches"""
+    """Configures the processor to send a list of messages to the call handler"""
 
     def __init__(self, batch_size):
         self.number_of_messages = batch_size

--- a/sqs_workers/batching.py
+++ b/sqs_workers/batching.py
@@ -1,0 +1,47 @@
+from abc import ABC, abstractmethod
+
+
+class BatchingConfiguration(ABC):
+    """
+    Abstract class defining the contract for configuring whether
+    a processor receives messages 1 by 1, or processes them in batch.
+    """
+
+    @property
+    @abstractmethod
+    def batching_enabled(self) -> bool:
+        """If false, process messages 1 by 1, otherwise process in batch"""
+        ...
+
+    @property
+    @abstractmethod
+    def batch_size(self) -> int:
+        """Number of messages to process at once if batching_enabled"""
+        ...
+
+
+class NoBatching(BatchingConfiguration):
+    """Configures the processor to process each message 1 by 1"""
+
+    @property
+    def batching_enabled(self) -> bool:
+        return False
+
+    @property
+    def batch_size(self) -> int:
+        return 1
+
+
+class BatchMessages(BatchingConfiguration):
+    """Configures the processor to process the messages in batches"""
+
+    def __init__(self, number_of_messages):
+        self.number_of_messages = number_of_messages
+
+    @property
+    def batching_enabled(self) -> bool:
+        return True
+
+    @property
+    def batch_size(self) -> int:
+        return self.number_of_messages

--- a/sqs_workers/batching.py
+++ b/sqs_workers/batching.py
@@ -35,8 +35,8 @@ class NoBatching(BatchingConfiguration):
 class BatchMessages(BatchingConfiguration):
     """Configures the processor to process the messages in batches"""
 
-    def __init__(self, number_of_messages):
-        self.number_of_messages = number_of_messages
+    def __init__(self, batch_size):
+        self.number_of_messages = batch_size
 
     @property
     def batching_enabled(self) -> bool:

--- a/sqs_workers/config.py
+++ b/sqs_workers/config.py
@@ -15,8 +15,8 @@ class Config(object):
     Config object with hierarchy support.
     """
 
-    parent = attr.ib(repr=False, default=None)  # type: Optional["Config"]
-    options = attr.ib(factory=dict)  # type: Dict[str, Any]
+    parent: Optional["Config"] = attr.ib(repr=False, default=None)
+    options: Dict[str, Any] = attr.ib(factory=dict)
     maker_key = attr.ib(default="maker")
 
     def __setitem__(self, key, value):

--- a/sqs_workers/core.py
+++ b/sqs_workers/core.py
@@ -11,8 +11,7 @@ class BatchProcessingResult(object):
         self.succeeded = succeeded or []
         self.failed = failed or []
 
-    def update_with_message(self, message, success):
-        # type: (Any, bool) -> None
+    def update_with_message(self, message: Any, success: bool):
         """
         Update processing result with a message.
         """

--- a/sqs_workers/deadletter_queue.py
+++ b/sqs_workers/deadletter_queue.py
@@ -36,7 +36,7 @@ class DeadLetterQueue(RawQueue):
     and quit.
     """
 
-    upstream_queue = attr.ib(default=None)  # type: GenericQueue
+    upstream_queue: "GenericQueue" = attr.ib(default=None)
 
     @classmethod
     def maker(cls, upstream_queue, **kwargs):
@@ -49,7 +49,7 @@ class DeadLetterQueue(RawQueue):
 @attr.s
 class PushBackSender(object):
 
-    upstream_queue = attr.ib(default=None)  # type: GenericQueue
+    upstream_queue: "GenericQueue" = attr.ib(default=None)
 
     def __call__(self, message):
         kwargs = {

--- a/sqs_workers/memory_sqs.py
+++ b/sqs_workers/memory_sqs.py
@@ -28,15 +28,15 @@ class MemoryAWS(object):
     In-memory AWS as a whole.
     """
 
-    client = attr.ib(
+    client: "MemoryClient" = attr.ib(
         repr=False,
         default=attr.Factory(lambda self: MemoryClient(self), takes_self=True),
-    )  # type: "MemoryClient"
-    resource = attr.ib(
+    )
+    resource: "ServiceResource" = attr.ib(
         repr=False,
         default=attr.Factory(lambda self: ServiceResource(self), takes_self=True),
-    )  # type: "ServiceResource"
-    queues = attr.ib(factory=list)  # type: List["MemoryQueue"]
+    )
+    queues: List["MemoryQueue"] = attr.ib(factory=list)
 
     def create_queue(self, QueueName, Attributes):
         queue = MemoryQueue(self, QueueName, Attributes)
@@ -88,7 +88,7 @@ class MemoryClient(object):
 @attr.s
 class ServiceResource(object):
 
-    aws = attr.ib(repr=False)  # type: MemoryAWS
+    aws: MemoryAWS = attr.ib(repr=False)
 
     def create_queue(self, QueueName, Attributes):
         return self.aws.create_queue(QueueName, Attributes)
@@ -109,10 +109,10 @@ class MemoryQueue(object):
          services/sqs.html#queue
     """
 
-    aws = attr.ib()  # type: MemoryAWS
-    name = attr.ib()  # type: str
-    attributes = attr.ib()  # type: Dict[str, Dict[str, str]]
-    messages = attr.ib(factory=list)  # type: List[MemoryMessage]
+    aws: MemoryAWS = attr.ib()
+    name: str = attr.ib()
+    attributes: Dict[str, Dict[str, str]] = attr.ib()
+    messages: List["MemoryMessage"] = attr.ib(factory=list)
 
     def __attrs_post_init__(self):
         self.attributes["QueueArn"] = self.name
@@ -198,26 +198,26 @@ class MemoryMessage(object):
          services/sqs.html#SQS.Message
     """
 
-    queue_impl = attr.ib()  # type: MemoryQueue
+    queue_impl: MemoryQueue = attr.ib()
 
     # The message's contents (not URL-encoded).
-    body = attr.ib()  # type: bytes
+    body: bytes = attr.ib()
 
     # Each message attribute consists of a Name, Type, and Value.
-    message_attributes = attr.ib(factory=dict)  # type: Dict[str, Dict[str, str]]
+    message_attributes: Dict[str, Dict[str, str]] = attr.ib(factory=dict)
 
     # A map of the attributes requested in `` ReceiveMessage `` to their
     # respective values.
-    attributes = attr.ib(factory=dict)  # type: Dict[str, Any]
+    attributes: Dict[str, Any] = attr.ib(factory=dict)
 
     # Internal attribute which contains the execution time.
-    execute_at = attr.ib(factory=datetime.datetime.utcnow)  # type: datetime.datetime
+    execute_at: datetime.datetime = attr.ib(factory=datetime.datetime.utcnow)
 
     # A unique identifier for the message
-    message_id = attr.ib(factory=lambda: uuid.uuid4().hex)  # type: str
+    message_id: str = attr.ib(factory=lambda: uuid.uuid4().hex)
 
     # The Message's receipt_handle identifier
-    receipt_handle = attr.ib(factory=lambda: uuid.uuid4().hex)  # type: str
+    receipt_handle: str = attr.ib(factory=lambda: uuid.uuid4().hex)
 
     @classmethod
     def from_kwargs(cls, queue_impl, kwargs):

--- a/sqs_workers/memory_sqs.py
+++ b/sqs_workers/memory_sqs.py
@@ -119,7 +119,7 @@ class MemoryQueue(object):
 
     @property
     def url(self):
-        return "memory://{}".format(self.name)
+        return f"memory://{self.name}"
 
     def send_message(self, **kwargs):
         message = MemoryMessage.from_kwargs(self, kwargs)

--- a/sqs_workers/processors.py
+++ b/sqs_workers/processors.py
@@ -25,11 +25,11 @@ class Processor(object):
     SQS message
     """
 
-    queue = attr.ib()  # type: GenericQueue
-    fn = attr.ib(default=None)  # type: Optional[Callable]
-    job_name = attr.ib(default="")  # type: str
-    pass_context = attr.ib(default=False)  # type: bool
-    context_var = attr.ib(default=DEFAULT_CONTEXT_VAR)  # type: str
+    queue: "GenericQueue" = attr.ib()
+    fn: Optional[Callable] = attr.ib(default=None)
+    job_name: str = attr.ib(default="")
+    pass_context: bool = attr.ib(default=False)
+    context_var: str = attr.ib(default=DEFAULT_CONTEXT_VAR)
 
     @classmethod
     def maker(cls, **kwargs):

--- a/sqs_workers/processors.py
+++ b/sqs_workers/processors.py
@@ -101,7 +101,7 @@ class Processor(object):
                 job_kwargs[self.context_var] = job_context
             deserialized_messages.append(job_kwargs)
 
-        call_handler(self.fn, [messages], {})
+        call_handler(self.fn, [deserialized_messages], {})
 
     def copy(self, **kwargs):
         """

--- a/sqs_workers/processors.py
+++ b/sqs_workers/processors.py
@@ -44,7 +44,7 @@ class Processor(object):
             "queue_name": self.queue.name,
             "job_name": self.job_name,
         }
-        logger.debug("Process {queue_name}.{job_name}".format(**extra), extra=extra)
+        logger.debug("Process %s.%s", self.queue.name, self.job_name, extra=extra)
 
         try:
             content_type, job_kwargs, job_context = self.deserialize_message(message)
@@ -52,7 +52,9 @@ class Processor(object):
             self.process(job_kwargs, job_context)
         except Exception:
             logger.exception(
-                "Error while processing {queue_name}.{job_name}".format(**extra),
+                "Error while processing %s.%s",
+                self.queue.name,
+                self.job_name,
                 extra=extra,
             )
             return False
@@ -71,16 +73,19 @@ class Processor(object):
             "job_name": self.job_name,
         }
         logger.debug(
-            "Processing batch for {queue_name}.{job_name}".format(**extra), extra=extra
+            "Processing batch for %s.%s",
+            self.queue.name,
+            self.job_name,
+            extra=extra,
         )
 
         try:
             self.process_batch(messages)
         except Exception:
             logger.exception(
-                "Error while processing batch for {queue_name}.{job_name}".format(
-                    **extra
-                ),
+                "Error while processing batch for %s.%s",
+                self.queue.name,
+                self.job_name,
                 extra=extra,
             )
             return False

--- a/sqs_workers/processors.py
+++ b/sqs_workers/processors.py
@@ -60,7 +60,7 @@ class Processor(object):
         effective_kwargs = job_kwargs.copy()
         if self.pass_context:
             effective_kwargs[self.context_var] = job_context
-        return call_handler(self.fn, effective_kwargs)
+        return call_handler(self.fn, [], effective_kwargs)
 
     def copy(self, **kwargs):
         """
@@ -92,11 +92,11 @@ def get_job_context(job_message, codec):
     return SQSContext.from_dict(deserialized)
 
 
-def call_handler(fn, kwargs):
+def call_handler(fn, args, kwargs):
     try:
-        handler_args, handler_kwargs = validate_arguments(fn, [], kwargs)
+        handler_args, handler_kwargs = validate_arguments(fn, args, kwargs)
     except TypeError:
         # it may happen, if "fn" is not a function (but
         # a mock object, for example)
-        handler_args, handler_kwargs = [], kwargs
+        handler_args, handler_kwargs = args, kwargs
     return fn(*handler_args, **handler_kwargs)

--- a/sqs_workers/queue.py
+++ b/sqs_workers/queue.py
@@ -11,7 +11,7 @@ import attr
 from sqs_workers import DEFAULT_BACKOFF, codecs
 from sqs_workers.async_task import AsyncTask
 from sqs_workers.backoff_policies import BackoffPolicy
-from sqs_workers.batching import BatchingConfiguration, BatchMessages, NoBatching
+from sqs_workers.batching import BatchingConfiguration, NoBatching
 from sqs_workers.core import BatchProcessingResult, get_job_name
 from sqs_workers.exceptions import SQSError
 from sqs_workers.processors import DEFAULT_CONTEXT_VAR, Processor
@@ -210,26 +210,6 @@ class RawQueue(GenericQueue):
 
         return func
 
-    def raw_batch_processor(self, batch_size=10):
-        """
-        Decorator to assign a batch processor to handle jobs from the raw queue
-
-        Usage example:
-
-            cron = sqs.queue('cron')
-
-            @cron.raw_batch_processor(batch_size=20)
-            def process(messages):
-                for message in messages:
-                    print(message['body'])
-        """
-        self.batching_policy = BatchMessages(batch_size)
-
-        def func(processor):
-            return self.connect_raw_processor(processor)
-
-        return func
-
     def connect_raw_processor(self, processor):
         """
         Assign raw processor (a function) to handle jobs.
@@ -374,41 +354,6 @@ class JobQueue(GenericQueue):
             )
 
         return fn
-
-    def batch_processor(
-        self,
-        job_name,
-        batch_size=10,
-        pass_context=False,
-        context_var=DEFAULT_CONTEXT_VAR,
-    ):
-        """
-        Decorator to assign a batch processor to handle jobs with
-        the name job_name from the queue queue_name
-
-        Usage example:
-
-            queue = sqs.queue('q1')
-
-            @queue.batch_processor('say_hello', batch_size=20)
-            def say_hello(messages):
-                for message in messages:
-                    print("Hello, " + message['name'])
-
-        Then you can add messages to the queue by calling ".delay" attribute
-        of a newly created object:
-
-            say_hello.delay(name='John')
-
-        Here, instead of calling function locally, it will be pushed to the
-        queue (essentially, mimics the non-blocking call of the function).
-
-        If you still want to call function locally, you can call
-
-            say_hello(name='John')
-        """
-        self.batching_policy = BatchMessages(batch_size)
-        return self.processor(job_name, pass_context, context_var)
 
     def connect_processor(
         self, job_name, processor, pass_context=False, context_var=DEFAULT_CONTEXT_VAR

--- a/sqs_workers/queue.py
+++ b/sqs_workers/queue.py
@@ -4,7 +4,7 @@ import warnings
 from collections import defaultdict
 from contextlib import contextmanager
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 import attr
 
@@ -36,7 +36,7 @@ class GenericQueue(object):
     env = attr.ib(repr=False)  # type: SQSEnv
     name = attr.ib()  # type: str
     backoff_policy = attr.ib(default=DEFAULT_BACKOFF)  # type: BackoffPolicy
-    batching_policy = attr.ib(default=NoBatching)  # type: Type[BatchingConfiguration]
+    batching_policy = attr.ib(default=NoBatching())  # type: BatchingConfiguration
     _queue = attr.ib(repr=False, default=None)
 
     @classmethod

--- a/sqs_workers/queue.py
+++ b/sqs_workers/queue.py
@@ -32,10 +32,10 @@ class SQSBatchError(SQSError):
 
 @attr.s
 class GenericQueue(object):
-    env = attr.ib(repr=False)  # type: SQSEnv
-    name = attr.ib()  # type: str
-    backoff_policy = attr.ib(default=DEFAULT_BACKOFF)  # type: BackoffPolicy
-    batching_policy = attr.ib(default=NoBatching())  # type: BatchingConfiguration
+    env: "SQSEnv" = attr.ib(repr=False)
+    name: str = attr.ib()
+    backoff_policy: BackoffPolicy = attr.ib(default=DEFAULT_BACKOFF)
+    batching_policy: BatchingConfiguration = attr.ib(default=NoBatching())
     _queue = attr.ib(repr=False, default=None)
 
     @classmethod
@@ -70,8 +70,7 @@ class GenericQueue(object):
                 )
                 break
 
-    def process_batch(self, wait_seconds=0):
-        # type: (int) -> BatchProcessingResult
+    def process_batch(self, wait_seconds=0) -> BatchProcessingResult:
         """
         Process a batch of messages from the queue (10 messages at most), return
         the number of successfully processed messages, and exit
@@ -120,8 +119,7 @@ class GenericQueue(object):
                 message.change_visibility(VisibilityTimeout=timeout)
         return result
 
-    def process_message(self, message):
-        # type: (Any) -> bool
+    def process_message(self, message: Any) -> bool:
         """
         Process single message.
 
@@ -129,8 +127,7 @@ class GenericQueue(object):
         """
         raise NotImplementedError()
 
-    def process_messages(self, messages):
-        # type: (Any) -> bool
+    def process_messages(self, messages: List[Any]) -> bool:
         """
         Process a batch of messages.
 
@@ -191,7 +188,7 @@ class GenericQueue(object):
 
 @attr.s
 class RawQueue(GenericQueue):
-    processor = attr.ib(default=None)  # type: Optional[Callable]
+    processor: Optional[Callable] = attr.ib(default=None)
 
     def raw_processor(self):
         """
@@ -229,10 +226,10 @@ class RawQueue(GenericQueue):
 
     def add_raw_job(
         self,
-        message_body,  # type: str
-        delay_seconds=0,  # type: int
-        deduplication_id=None,  # type: Optional[str]
-        group_id=DEFAULT_MESSAGE_GROUP_ID,  # type: str
+        message_body: str,
+        delay_seconds: int = 0,
+        deduplication_id: Optional[str] = None,
+        group_id: str = DEFAULT_MESSAGE_GROUP_ID,
     ):
         """
         Add raw message to the queue
@@ -257,8 +254,7 @@ class RawQueue(GenericQueue):
         ret = self.get_queue().send_message(**kwargs)
         return ret["MessageId"]
 
-    def process_message(self, message):
-        # type: (Any) -> bool
+    def process_message(self, message: Any) -> bool:
         """
         Sends a single message to the call handler.
 
@@ -286,8 +282,7 @@ class RawQueue(GenericQueue):
         else:
             return True
 
-    def process_messages(self, messages):
-        # type: (Any) -> bool
+    def process_messages(self, messages: List[Any]) -> bool:
         """
         Sends a list of messages to the call handler
 
@@ -326,10 +321,10 @@ class RawQueue(GenericQueue):
 
 @attr.s
 class JobQueue(GenericQueue):
-    processors = attr.ib(factory=dict)  # type: Dict[str, Processor]
+    processors: Dict[str, Processor] = attr.ib(factory=dict)
 
-    _batch_level = attr.ib(default=0, repr=False)  # type: int
-    _batched_messages = attr.ib(factory=list, repr=False)  # type: List[Dict]
+    _batch_level: int = attr.ib(default=0, repr=False)
+    _batched_messages: List[Dict] = attr.ib(factory=list, repr=False)
 
     def processor(self, job_name, pass_context=False, context_var=DEFAULT_CONTEXT_VAR):
         """
@@ -533,8 +528,7 @@ class JobQueue(GenericQueue):
             ret = queue.send_message(**kwargs)
             return ret["MessageId"]
 
-    def process_message(self, message):
-        # type: (Any) -> bool
+    def process_message(self, message: Any) -> bool:
         """
         Sends a single message to the call handler.
 
@@ -547,8 +541,7 @@ class JobQueue(GenericQueue):
         else:
             return self.process_message_fallback(job_name)
 
-    def process_messages(self, messages):
-        # type: (Any) -> bool
+    def process_messages(self, messages: List[Any]) -> bool:
         """
         Sends a list of messages to the call handler
 
@@ -576,8 +569,7 @@ class JobQueue(GenericQueue):
         logger.warning("Error while processing %s.%s", self.name, job_name)
         return False
 
-    def copy_processors(self, dst_queue):
-        # type: (JobQueue) -> None
+    def copy_processors(self, dst_queue: "JobQueue"):
         """
         Copy processors from self to dst_queue. Can be helpful to process d
         ead-letter queue with processors from the main queue.

--- a/sqs_workers/queue.py
+++ b/sqs_workers/queue.py
@@ -257,7 +257,7 @@ class RawQueue(GenericQueue):
     def process_message(self, message):
         # type: (Any) -> bool
         """
-        Process single message.
+        Sends a single message to the call handler.
 
         Return True if processing went successful
         """
@@ -284,7 +284,7 @@ class RawQueue(GenericQueue):
     def process_messages(self, messages):
         # type: (Any) -> bool
         """
-        Process a batch of messages, grouped by job type.
+        Sends a list of messages to the call handler
 
         Return True if processing went successful for all messages in the batch.
         """
@@ -316,7 +316,6 @@ class RawQueue(GenericQueue):
 
 @attr.s
 class JobQueue(GenericQueue):
-
     processors = attr.ib(factory=dict)  # type: Dict[str, Processor]
 
     _batch_level = attr.ib(default=0, repr=False)  # type: int
@@ -525,7 +524,7 @@ class JobQueue(GenericQueue):
     def process_message(self, message):
         # type: (Any) -> bool
         """
-        Process single message.
+        Sends a single message to the call handler.
 
         Return True if processing went successful
         """
@@ -539,7 +538,7 @@ class JobQueue(GenericQueue):
     def process_messages(self, messages):
         # type: (Any) -> bool
         """
-        Process a batch of messages, grouped by job type.
+        Sends a list of messages to the call handler
 
         Return True if processing went successful for all messages in the batch.
         """

--- a/sqs_workers/shutdown_policies.py
+++ b/sqs_workers/shutdown_policies.py
@@ -45,7 +45,7 @@ class IdleShutdown(object):
         return now() - self._last_seen >= self._idle_delta
 
     def __repr__(self):
-        return "IdleShutdown({})".format(self.idle_seconds)
+        return f"IdleShutdown({self.idle_seconds})"
 
 
 class MaxTasksShutdown(object):
@@ -65,7 +65,7 @@ class MaxTasksShutdown(object):
         return self._tasks >= self.max_tasks
 
     def __repr__(self):
-        return "MaxTasksShutdown({})".format(self.max_tasks)
+        return f"MaxTasksShutdown({self.max_tasks})"
 
 
 class OrShutdown(object):
@@ -88,7 +88,7 @@ class OrShutdown(object):
 
     def __repr__(self):
         repr_policies = ", ".join([repr(p) for p in self.policies])
-        return "OrShutdown({})".format(repr_policies)
+        return f"OrShutdown({repr_policies})"
 
 
 class AndShutdown(object):
@@ -111,7 +111,7 @@ class AndShutdown(object):
 
     def __repr__(self):
         repr_policies = ", ".join([repr(p) for p in self.policies])
-        return "AndShutdown({})".format(repr_policies)
+        return f"AndShutdown({repr_policies})"
 
 
 NEVER_SHUTDOWN = NeverShutdown()

--- a/sqs_workers/sqs_env.py
+++ b/sqs_workers/sqs_env.py
@@ -97,7 +97,7 @@ class SQSEnv(object):
         _delay_seconds=None,
         _deduplication_id=None,
         _group_id=None,
-        **job_kwargs
+        **job_kwargs,
     ):
         """
         Add job to the queue.
@@ -113,7 +113,7 @@ class SQSEnv(object):
             _delay_seconds=_delay_seconds,
             _deduplication_id=_deduplication_id,
             _group_id=_group_id,
-            **job_kwargs
+            **job_kwargs,
         )
 
     def process_queues(self, queue_names=None, shutdown_policy_maker=NeverShutdown):
@@ -160,7 +160,7 @@ class SQSEnv(object):
         ("low level") name by simply prefixing it. Used to create namespaces
         for different environments (development, staging, production, etc)
         """
-        return "{}{}".format(self.queue_prefix, queue_name)
+        return f"{self.queue_prefix}{queue_name}"
 
     def redrive_policy(self, dead_letter_queue_name, max_receive_count):
         return RedrivePolicy(self, dead_letter_queue_name, max_receive_count)

--- a/sqs_workers/sqs_env.py
+++ b/sqs_workers/sqs_env.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-AnyQueue = Union[GenericQueue, JobQueue]
+AnyQueue = Union[GenericQueue, JobQueue, RawQueue]
 
 
 @attr.s
@@ -52,7 +52,7 @@ class SQSEnv(object):
         queue_maker=JobQueue,  # type: Type[AnyQueue]
         backoff_policy=None,  # type: Optional[BackoffPolicy]
     ):
-        # type: (...) -> GenericQueue
+        # type: (...) -> AnyQueue
         """
         Get a queue object, initializing it with queue_maker if necessary.
         """

--- a/sqs_workers/sqs_env.py
+++ b/sqs_workers/sqs_env.py
@@ -64,21 +64,25 @@ class SQSEnv(object):
         return self.queues[queue_name]
 
     def processor(
-        self, queue_name, job_name, pass_context=False, context_var=DEFAULT_CONTEXT_VAR
+        self,
+        queue_name: str,
+        job_name: str,
+        pass_context=False,
+        context_var=DEFAULT_CONTEXT_VAR
     ):
         """
         Decorator to attach processor to all jobs "job_name" of the queue "queue_name".
         """
-        q = self.queue(queue_name, queue_maker=JobQueue)  # type: JobQueue
+        q: JobQueue = self.queue(queue_name, queue_maker=JobQueue)
         return q.processor(
             job_name=job_name, pass_context=pass_context, context_var=context_var
         )
 
-    def raw_processor(self, queue_name):
+    def raw_processor(self, queue_name: str):
         """
         Decorator to attach raw processor to all jobs of the queue "queue_name".
         """
-        q = self.queue(queue_name, queue_maker=RawQueue)  # type: RawQueue
+        q: RawQueue = self.queue(queue_name, queue_maker=RawQueue)
         return q.raw_processor()
 
     def add_job(

--- a/sqs_workers/sqs_env.py
+++ b/sqs_workers/sqs_env.py
@@ -25,7 +25,6 @@ AnyQueue = Union[GenericQueue, JobQueue, RawQueue]
 
 @attr.s
 class SQSEnv(object):
-
     session = attr.ib(default=boto3)
     queue_prefix = attr.ib(default="")
 

--- a/sqs_workers/sqs_env.py
+++ b/sqs_workers/sqs_env.py
@@ -7,6 +7,7 @@ import attr
 import boto3
 
 from sqs_workers import DEFAULT_BACKOFF, RawQueue, codecs, context, processors
+from sqs_workers.batching import BatchingConfiguration, NoBatching
 from sqs_workers.core import RedrivePolicy
 from sqs_workers.processors import DEFAULT_CONTEXT_VAR
 from sqs_workers.queue import GenericQueue, JobQueue
@@ -50,6 +51,7 @@ class SQSEnv(object):
         self,
         queue_name,  # type: str
         queue_maker=JobQueue,  # type: Type[AnyQueue]
+        batching_policy=NoBatching(),  # type: BatchingConfiguration
         backoff_policy=None,  # type: Optional[BackoffPolicy]
     ):
         # type: (...) -> AnyQueue
@@ -61,6 +63,7 @@ class SQSEnv(object):
             self.queues[queue_name] = queue_maker(
                 env=self,
                 name=queue_name,
+                batching_policy=batching_policy,
                 backoff_policy=backoff_policy,
             )
         return self.queues[queue_name]
@@ -80,39 +83,12 @@ class SQSEnv(object):
             job_name=job_name, pass_context=pass_context, context_var=context_var
         )
 
-    def batch_processor(
-        self,
-        queue_name: str,
-        job_name: str,
-        batch_size: int = 10,
-        pass_context=False,
-        context_var=DEFAULT_CONTEXT_VAR,
-    ):
-        """
-        Decorator to attach a batch processor to all jobs "job_name"
-        of the queue "queue_name".
-        """
-        q: JobQueue = self.queue(queue_name, queue_maker=JobQueue)  # type: ignore
-        return q.batch_processor(
-            job_name=job_name,
-            batch_size=batch_size,
-            pass_context=pass_context,
-            context_var=context_var,
-        )
-
     def raw_processor(self, queue_name: str):
         """
         Decorator to attach raw processor to all jobs of the queue "queue_name".
         """
         q: RawQueue = self.queue(queue_name, queue_maker=RawQueue)  # type: ignore
         return q.raw_processor()
-
-    def raw_batch_processor(self, queue_name: str, batch_size: int = 10):
-        """
-        Decorator to attach a raw batch processor to all jobs of the queue "queue_name".
-        """
-        q: RawQueue = self.queue(queue_name, queue_maker=RawQueue)  # type: ignore
-        return q.raw_batch_processor(batch_size=batch_size)
 
     def add_job(
         self,

--- a/sqs_workers/sqs_env.py
+++ b/sqs_workers/sqs_env.py
@@ -39,7 +39,7 @@ class SQSEnv(object):
     context = attr.ib(default=None)
     sqs_client = attr.ib(default=None)
     sqs_resource = attr.ib(default=None)
-    queues = attr.ib(init=False, factory=dict)  # type: Dict[str, AnyQueue]
+    queues: Dict[str, AnyQueue] = attr.ib(init=False, factory=dict)
 
     def __attrs_post_init__(self):
         self.context = self.context_maker()
@@ -48,12 +48,11 @@ class SQSEnv(object):
 
     def queue(
         self,
-        queue_name,  # type: str
-        queue_maker=JobQueue,  # type: Type[AnyQueue]
-        batching_policy=NoBatching(),  # type: BatchingConfiguration
-        backoff_policy=None,  # type: Optional[BackoffPolicy]
-    ):
-        # type: (...) -> AnyQueue
+        queue_name: str,
+        queue_maker: Type[AnyQueue] = JobQueue,
+        batching_policy: BatchingConfiguration = NoBatching(),
+        backoff_policy: Optional["BackoffPolicy"] = None,
+    ) -> AnyQueue:
         """
         Get a queue object, initializing it with queue_maker if necessary.
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,6 @@ def sqs(sqs_session):
 
 @pytest.fixture
 def queue_name(sqs_session, sqs, random_string):
-    # type: (SQSEnv) -> string
     create_standard_queue(sqs, random_string)
     yield random_string
     delete_queue(sqs, random_string)
@@ -37,7 +36,6 @@ def queue_name(sqs_session, sqs, random_string):
 
 @pytest.fixture
 def queue_name2(sqs_session, sqs, random_string):
-    # type: (SQSEnv) -> string
     create_standard_queue(sqs, random_string + "_2")
     yield random_string + "_2"
     delete_queue(sqs, random_string + "_2")
@@ -65,7 +63,6 @@ def queue_name_with_redrive(sqs_session, sqs, random_string):
 
 @pytest.fixture
 def fifo_queue_name(sqs_session, sqs, random_string):
-    # type: (SQSEnv) -> string
     queue_name = random_string + ".fifo"
     create_fifo_queue(sqs, queue_name)
     yield queue_name

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -232,9 +232,9 @@ def test_redrive(sqs_session, sqs, queue_name_with_redrive):
 def test_deadletter_processor(sqs, queue_name_with_redrive):
     queue_name, dead_queue_name = queue_name_with_redrive
     queue = sqs.queue(queue_name, RawQueue)
-    dead_queue = sqs.queue(
+    dead_queue: DeadLetterQueue = sqs.queue(
         dead_queue_name, DeadLetterQueue.maker(upstream_queue=queue)
-    )  # type: DeadLetterQueue
+    )
 
     dead_queue.add_raw_job("say_hello")
     assert dead_queue.process_batch(wait_seconds=0).succeeded_count() == 1
@@ -359,7 +359,7 @@ def test_raw_queue(sqs, queue_name):
     def raw_processor(message):
         message_body["body"] = message.body
 
-    queue = sqs.queue(queue_name, RawQueue)  # type: RawQueue
+    queue: RawQueue = sqs.queue(queue_name, RawQueue)
     queue.connect_raw_processor(raw_processor)
     queue.add_raw_job("foo")
     assert queue.process_batch().succeeded_count() == 1
@@ -369,7 +369,7 @@ def test_raw_queue(sqs, queue_name):
 def test_raw_queue_decorator(sqs, queue_name):
     message_body = {}
 
-    queue = sqs.queue(queue_name, RawQueue)  # type: RawQueue
+    queue: RawQueue = sqs.queue(queue_name, RawQueue)
 
     @queue.raw_processor()
     def raw_processor(message):

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -401,3 +401,17 @@ def test_batch_processor_run_executes_task_immediately(sqs, queue_name):
     batch_say_hello_task.run(username="Homer")
     assert len(batch_results) == 1
     assert batch_results[0] == "Homer_0"
+
+
+def test_batch_processor_run_raises_type_error_if_unnamed_args_used(sqs, queue_name):
+    queue = sqs.queue(queue_name, batching_policy=batching.BatchMessages(batch_size=5))
+    batch_say_hello_task = queue.connect_processor("batch_say_hello", batch_say_hello)
+    with pytest.raises(TypeError):
+        batch_say_hello_task.run(1, 2, 3)
+
+
+def test_batch_processor_delay_raises_type_error_if_non_kwargs_used(sqs, queue_name):
+    queue = sqs.queue(queue_name, batching_policy=batching.BatchMessages(batch_size=5))
+    batch_say_hello_task = queue.connect_processor("batch_say_hello", batch_say_hello)
+    with pytest.raises(TypeError):
+        batch_say_hello_task.delay(1, 2, 3)

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -391,6 +391,9 @@ def test_batch_processor(sqs, queue_name):
     queue.process_batch(wait_seconds=0)
     assert len(batch_results) == 5
 
+    queue.process_batch(wait_seconds=0)
+    assert len(batch_results) == 10
+
 
 def test_batch_processor_run_executes_task_immediately(sqs, queue_name):
     queue = sqs.queue(queue_name, batching_policy=batching.BatchMessages(batch_size=5))


### PR DESCRIPTION
Allow us to configure sending a batch of messages to a decorated call handler.

The workers already pull messages in batches by default (10 messages max over a 10 second long poll), this change allows us to send all of those messages to a function to be processed in one go.

Intended for scenarios where batching up messages (say ingesting data into a database, or search index) would be more performant than doing it individually

Example usage:

```python
sqs = SQSEnv()

create_standard_queue(sqs, "emails")

queue = sqs.queue("emails", batching_policy=BatchMessages(batch_size=10))

@queue.processor("send_email")
def send_email(messages: list):
    for email in messages:
        print(f"Sending email {email['subject']} to {email['to']}")
```

**Important Notes:**

* Configured at **queue** level, not processor level
    * This is as we already pick up messages in batch from a queue then distribute them across all configured jobs
* If the call handler fails, all messages in the batch are discarded and requeued based on the configured queue visibility and retry policy
    * As such the call handler should expect duplicates and be idemponent
* Changes the internals of `Processor`
    * As we encourage inheritance and customisation of the `Processor` in our README, is it worth making this a major version bump to denote breaking changes (do we use semantic versioning in this project?)

