### PR TITLE
Modernize codecs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,8 @@
 
 ### Added
 
-- New codec (message encoding) that uses the default version of the Pickle protocol instead of one compatible with Python 2
+- New codec (message encoding) that uses the default version of the Pickle protocol instead of one compatible with Python 2.
+- Possibility to change default codec in SQSEnv.
 
 ### Changed
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,13 @@
 ## [Unrealesed]
 
+### Added
+
+- New codec (message encoding) that uses the default version of the Pickle protocol instead of one compatible with Python 2
+
 ### Changed
 
 - When a processor for a job can't be found, we now log this as an error (rather than a warning) and provide a more helpful error message.
+- Default codec is renamed from "pickle" to "pickle_compat".
 
 ## [0.5.8] - 2022-08-31
 

--- a/README.md
+++ b/README.md
@@ -424,6 +424,19 @@ Usage example:
 
 This code takes all the messages in the foo_dead queue and executes them with processors from the "foo" queue. Then it waits 10 seconds to ensure no new messages appear, and quit.
 
+## Codecs
+
+Before being added to SQS, task parameters are encoded using a `Codec`. At the moment, 3 codecs are available:
+- `pickle`: serialize with Pickle, using the default protocol version;
+- `pickle_compat`: serialize with Pickle, using protocol version 2, which is compatible with Python 2;
+- `json`: serialize with JSON.
+
+By default, `pickle_compat` is used, for backward compatibility with previous versions of sqs-workers.
+
+JSON is recommended if using untrusted data (see the notes about security in the [pickle docs](https://docs.python.org/3/library/pickle.html), or for compatibility with other systems. In all other cases, you should use `pickle` instead of `pickle_compat`, as it's more compact and efficient:
+
+    >>> env = SQSEnv(codec="pickle")
+
 ## Using in unit tests with MemorySession
 
 There is a special MemorySession, which can be used as a quick and dirty replacement for real queues in unit tests. If you have a function `create_task` which adds some tasks to the queue and you want to test how it works, you can technically write your tests like this:

--- a/sqs_workers/async_task.py
+++ b/sqs_workers/async_task.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Callable
 
-from sqs_workers.codecs import DEFAULT_CONTENT_TYPE
 from sqs_workers.utils import bind_arguments
 
 if TYPE_CHECKING:
@@ -50,7 +49,7 @@ class AsyncTask(object):
         """
         Run the task asynchronously.
         """
-        _content_type = kwargs.pop("_content_type", DEFAULT_CONTENT_TYPE)
+        _content_type = kwargs.pop("_content_type", self.queue.env.codec)
         _delay_seconds = kwargs.pop("_delay_seconds", None)
         _deduplication_id = kwargs.pop("_deduplication_id", None)
         _group_id = kwargs.pop("_group_id", None)

--- a/sqs_workers/codecs.py
+++ b/sqs_workers/codecs.py
@@ -2,39 +2,60 @@ import base64
 import json
 import pickle
 import zlib
+from typing import Any, ClassVar, Dict, Protocol, Type
 
-DEFAULT_CONTENT_TYPE = "pickle"
+DEFAULT_CONTENT_TYPE = "pickle_compat"
 
 # Highest version of the protocol, understood by Python2.
 PICKLE_PY2_COMPAT_PROTO = 2
 
 
-class JSONCodec(object):
-    @staticmethod
-    def serialize(message):
+class Codec(Protocol):
+    @classmethod
+    def serialize(cls, message: Any) -> str:
+        ...
+
+    @classmethod
+    def deserialize(cls, serialized: str) -> Any:
+        ...
+
+
+class JSONCodec:
+    @classmethod
+    def serialize(cls, message: Any) -> str:
         return json.dumps(message)
 
-    @staticmethod
-    def deserialize(serialized):
+    @classmethod
+    def deserialize(cls, serialized: str) -> Any:
         return json.loads(serialized)
 
 
-class PickleCodec(object):
-    @staticmethod
-    def serialize(message):
-        binary_data = pickle.dumps(message, protocol=PICKLE_PY2_COMPAT_PROTO)
+class PickleCodec:
+    protocol: ClassVar[int] = pickle.DEFAULT_PROTOCOL
+
+    @classmethod
+    def serialize(cls, message: Any) -> str:
+        binary_data = pickle.dumps(message, protocol=cls.protocol)
         compressed_data = zlib.compress(binary_data)
         return base64.urlsafe_b64encode(compressed_data).decode("latin1")
 
-    @staticmethod
-    def deserialize(serialized):
+    @classmethod
+    def deserialize(cls, serialized: str) -> Any:
         compressed_data = base64.urlsafe_b64decode(serialized.encode("latin1"))
         binary_data = zlib.decompress(compressed_data)
         return pickle.loads(binary_data)
 
 
-def get_codec(content_type):
+class PickleCompatCodec(PickleCodec):
+    protocol = PICKLE_PY2_COMPAT_PROTO
+
+
+def get_codec(content_type: str) -> Type[Codec]:
     return CONTENT_TYPES_CODECS[content_type]
 
 
-CONTENT_TYPES_CODECS = {"json": JSONCodec, "pickle": PickleCodec}
+CONTENT_TYPES_CODECS: Dict[str, Type[Codec]] = {
+    "json": JSONCodec,
+    "pickle": PickleCodec,
+    "pickle_compat": PickleCompatCodec,
+}

--- a/sqs_workers/queue.py
+++ b/sqs_workers/queue.py
@@ -485,7 +485,7 @@ class JobQueue(GenericQueue):
     ):
         """
         Add job to the queue. The body of the job will be converted to the text
-        with one of the codes (by default it's "pickle")
+        with one of the codecs (by default it's "pickle_compat")
         """
         if not _content_type:
             _content_type = self.env.codec

--- a/sqs_workers/queue.py
+++ b/sqs_workers/queue.py
@@ -477,7 +477,7 @@ class JobQueue(GenericQueue):
     def add_job(
         self,
         job_name,
-        _content_type=codecs.DEFAULT_CONTENT_TYPE,
+        _content_type=None,
         _delay_seconds=None,
         _deduplication_id=None,
         _group_id=None,
@@ -487,6 +487,8 @@ class JobQueue(GenericQueue):
         Add job to the queue. The body of the job will be converted to the text
         with one of the codes (by default it's "pickle")
         """
+        if not _content_type:
+            _content_type = self.env.codec
         codec = codecs.get_codec(_content_type)
         message_body = codec.serialize(job_kwargs)
         job_context = codec.serialize(self.env.context.to_dict())

--- a/sqs_workers/sqs_env.py
+++ b/sqs_workers/sqs_env.py
@@ -27,6 +27,7 @@ AnyQueue = Union[GenericQueue, JobQueue, RawQueue]
 class SQSEnv(object):
     session = attr.ib(default=boto3)
     queue_prefix = attr.ib(default="")
+    codec: str = attr.ib(default=codecs.DEFAULT_CONTENT_TYPE)
 
     # queue-specific settings
     backoff_policy = attr.ib(default=DEFAULT_BACKOFF)
@@ -92,7 +93,7 @@ class SQSEnv(object):
         self,
         queue_name,
         job_name,
-        _content_type=codecs.DEFAULT_CONTENT_TYPE,
+        _content_type=None,
         _delay_seconds=None,
         _deduplication_id=None,
         _group_id=None,
@@ -105,6 +106,8 @@ class SQSEnv(object):
             "sqs.add_job() is deprecated. Use sqs.queue(...).add_job() instead",
             DeprecationWarning,
         )
+        if not _content_type:
+            _content_type = self.codec
         q = self.queue(queue_name, queue_maker=JobQueue)  # type: JobQueue
         return q.add_job(
             job_name,

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1,9 +1,9 @@
 import pytest
 
-from sqs_workers.codecs import JSONCodec, PickleCodec
+from sqs_workers.codecs import JSONCodec, PickleCodec, PickleCompatCodec
 
 
-@pytest.mark.parametrize("codec", [PickleCodec, JSONCodec])
+@pytest.mark.parametrize("codec", [PickleCodec, PickleCompatCodec, JSONCodec])
 def test_encode_decode(codec):
     foo = {"message": "hello world"}
     foo_str = codec.serialize(foo)


### PR DESCRIPTION
The current default codec uses Pickle with protocol version 2: compatible with Python2, but doesn't support `bytes`, very large objects, or more advanced features of later versions.

So, this PR renames that codec to `PickleCompat` (keeping it as default), adds a new codec to use the default protocol version (currently version 4 since Python 3.8, even though protocol 5 is available too), and makes it possible to configure it directly in `SQSEnv`, without having to update each call to `.delay()`/`.add_job()`.