### PR TITLE
feat: Allow overriding sqs_client, sqs_resource.

### DIFF
--- a/sqs_workers/sqs_env.py
+++ b/sqs_workers/sqs_env.py
@@ -44,8 +44,10 @@ class SQSEnv(object):
 
     def __attrs_post_init__(self):
         self.context = self.context_maker()
-        self.sqs_client = self.session.client("sqs")
-        self.sqs_resource = self.session.resource("sqs")
+        if not self.sqs_client:
+            self.sqs_client = self.session.client("sqs")
+        if not self.sqs_resource:
+            self.sqs_resource = self.session.resource("sqs")
 
     def queue(
         self,


### PR DESCRIPTION
This is a minor tweak to allow override of `sqs_client`, `sqs_resource`. This will make it possible to provide `endpoint_url` without changing interface.

ref.: https://github.com/Doist/backend-issues/issues/2549