### PR TITLE
chore: Adjust signature of MemorySession.client to match boto3.

### DIFF
--- a/sqs_workers/memory_sqs.py
+++ b/sqs_workers/memory_sqs.py
@@ -55,7 +55,7 @@ class MemorySession(object):
 
     aws = attr.ib(repr=False, factory=MemoryAWS)
 
-    def client(self, service_name):
+    def client(self, service_name, **kwargs):
         assert service_name == "sqs"
         return self.aws.client
 


### PR DESCRIPTION
Adjust signature so memory_aws can be used as a drop-in replacement.