### PR TITLE
chore: Update actions to support NodeJS 20

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         run:  docker run -d -p 4566:9324 --rm softwaremill/elasticmq-native
 
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
This PR updates the actions to versions that no longer rely on NodeJS 16, which has reached its end of life. By upgrading the actions, we ensure compatibility with the latest NodeJS 20 runtime.

For https://github.com/Doist/infrastructure-backlog/issues/628
