### PR TITLE
feat: add support to pass the queue url directly

### DIFF
--- a/sqs_workers/utils.py
+++ b/sqs_workers/utils.py
@@ -1,5 +1,6 @@
 import importlib
 import logging
+import re
 from inspect import Signature
 from typing import Any
 
@@ -129,3 +130,11 @@ def ensure_string(obj: Any, encoding="utf-8", errors="strict") -> str:
         return obj.decode(encoding, errors)
     else:
         return str(obj)
+
+
+def is_queue_url(queue_name: str):
+    """
+    Return true if the queue_name variable is an SQS queue url
+    """
+    sqs_queue_regex = r"(http|https)[:][\/]{2}[a-zA-Z0-9-_:.]+[\/][0-9]{12}[\/]{1}[a-zA-Z0-9-_]{0,80}"
+    return True if re.search(sqs_queue_regex, queue_name) else False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,13 @@ def queue_name2(sqs_session, sqs, random_string):
 
 
 @pytest.fixture
+def queue_url(sqs_session, sqs, random_string):
+    queue_url = create_standard_queue(sqs, random_string)
+    yield queue_url
+    delete_queue(sqs, random_string)
+
+
+@pytest.fixture
 def queue_name_with_redrive(sqs_session, sqs, random_string):
     # dead letter queue_name
     queue = random_string

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -64,6 +64,18 @@ def sqs_codec(sqs, codec):
     return codec
 
 
+def test_create_queue_with_queue_url(sqs_session, sqs, queue_url):
+    if isinstance(sqs_session, MemorySession):
+        pytest.skip("MemorySession doesn't produce a SQS compatible queue_url")
+    
+    expected_name = queue_url.split("/")[-1]
+    expected_private_queue = sqs.sqs_resource.Queue(queue_url)
+
+    queue = sqs.queue(queue_url)
+    assert queue.name == expected_name
+    assert queue._queue == expected_private_queue
+
+
 def test_add_job_with_codec(sqs, queue_name, codec):
     codec_name, codec_cls = codec
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from sqs_workers.utils import (
     bind_arguments,
     instantiate_from_dict,
     instantiate_from_string,
+    is_queue_url,
     string_to_object,
     validate_arguments,
 )
@@ -103,3 +104,18 @@ def test_bind_arguments_raises_on_extra():
                 "d": 4,
             },
         )
+
+
+@pytest.mark.parametrize(
+    "queue_name,expected",
+    [
+        ("https://sqs.us-east-1.amazonaws.com/177715257436", False),
+        ("https://sqs.us-east-1.amazonaws.com/1/MyQueue", False),
+        ("https://sqs.us-east-1.amazonaws.com/MyQueue", False),
+        ("http://localhost:9324/000000000000/sqs_workers_tests_20231213_gkzk7rh0ca", True),
+        ("https://localhost:9324/000000000000/sqs_workers_tests_20231213_gkzk7rh0ca", True),
+        ("https://sqs.us-east-1.amazonaws.com/177715257436/MyQueue", True),
+    ],
+)
+def test_is_queue_url(queue_name, expected):
+    assert expected == is_queue_url(queue_name)


### PR DESCRIPTION
When we pass the queue url directly we can avoid calling the AWS API in the get_queue method.

Fixes https://github.com/Doist/sqs-workers/issues/33