### PR TITLE
fix: avoid sending batches that are too large for SQS to process

### DIFF
--- a/sqs_workers/queue.py
+++ b/sqs_workers/queue.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import uuid
 from collections import defaultdict
@@ -29,6 +30,7 @@ from sqs_workers.shutdown_policies import NEVER_SHUTDOWN
 
 DEFAULT_MESSAGE_GROUP_ID = "default"
 SEND_BATCH_SIZE = 10
+MAX_SQS_MESSAGE_SIZE = 262144  # in bytes
 
 if TYPE_CHECKING:
     from sqs_workers import SQSEnv
@@ -450,6 +452,14 @@ class JobQueue(GenericQueue):
         want to improve that by also ensuring the batch size is small enough.
         """
         max_size = SEND_BATCH_SIZE if self._batch_level > 0 else 1
+
+        # A rough guess at the size of the message we will send to SQS
+        est_message_size = len(json.dumps(self._batched_messages).encode("utf-8"))
+
+        # Attempt to flush if we have gotten close to the message size limit
+        if est_message_size > MAX_SQS_MESSAGE_SIZE - 1024:
+            return True
+
         return len(self._batched_messages) >= max_size
 
     def _flush_batch_if_needed(self) -> None:
@@ -458,8 +468,16 @@ class JobQueue(GenericQueue):
         # There should be at most 1 batch to send. But just in case, prepare to
         # send more than that.
         while self._should_flush_batch():
-            msgs = self._batched_messages[:SEND_BATCH_SIZE]
-            self._batched_messages = self._batched_messages[SEND_BATCH_SIZE:]
+            send_batch_size = SEND_BATCH_SIZE
+
+            # A rough guess at the size of the message we will send to SQS
+            est_message_size = len(json.dumps(self._batched_messages).encode("utf-8"))
+            if est_message_size > MAX_SQS_MESSAGE_SIZE - 1024:
+                # If we have a really large batch, just send half of it at a time
+                send_batch_size = SEND_BATCH_SIZE / 2
+
+            msgs = self._batched_messages[:send_batch_size]
+            self._batched_messages = self._batched_messages[send_batch_size:]
 
             # Add Ids
             msg_by_id = {}


### PR DESCRIPTION
This is an attempt to avoid the "BatchRequestTooLong when batching jobs to SQS" seen in https://github.com/Doist/Issues/issues/12521?notification_referrer_id=NT_kwDOADLHH7I5MDA4MDA0NDczOjMzMjc3NzU#top.

The calculations and mitigations are just rough estimates, but should be enough to resolve most of the cases we are seeing.