### PR TITLE
fix: improved handling of api call failure

### DIFF
--- a/sqs_workers/memory_sqs.py
+++ b/sqs_workers/memory_sqs.py
@@ -181,12 +181,13 @@ class MemoryQueue:
         found_entries = []
         not_found_entries = []
 
+        now = datetime.datetime.utcnow()
+
         for e in Entries:
             if e["Id"] in self.in_flight:
                 found_entries.append(e)
                 in_flight_message = self.in_flight[e["Id"]]
                 sec = int(e["VisibilityTimeout"])
-                now = datetime.datetime.utcnow()
                 execute_at = now + datetime.timedelta(seconds=sec)
                 updated_message = attr.evolve(in_flight_message, execute_at=execute_at)
                 updated_message.attributes["ApproximateReceiveCount"] += 1

--- a/sqs_workers/queue.py
+++ b/sqs_workers/queue.py
@@ -10,9 +10,11 @@ from typing import (
     Callable,
     Dict,
     Generator,
+    Iterable,
     List,
     Literal,
     Optional,
+    Tuple,
     TypeVar,
 )
 
@@ -27,6 +29,7 @@ from sqs_workers.core import BatchProcessingResult, get_job_name
 from sqs_workers.exceptions import SQSError
 from sqs_workers.processors import DEFAULT_CONTEXT_VAR, Processor
 from sqs_workers.shutdown_policies import NEVER_SHUTDOWN
+from sqs_workers.utils import batcher
 
 DEFAULT_MESSAGE_GROUP_ID = "default"
 SEND_BATCH_SIZE = 10
@@ -85,53 +88,80 @@ class GenericQueue:
                 )
                 break
 
-    def process_batch(self, wait_seconds=0) -> BatchProcessingResult:
+    def process_batch(self, wait_seconds: int = 0) -> BatchProcessingResult:
         """
         Process a batch of messages from the queue (10 messages at most), return
         the number of successfully processed messages, and exit
         """
+        if self.batching_policy.batching_enabled:
+            messages = self.get_raw_messages(wait_seconds, self.batching_policy.batch_size)
+            success = self.process_messages(messages)
+            messages_with_success = ((m, success) for m in messages)
+        else:
+            messages = self.get_raw_messages(wait_seconds)
+            success = [self.process_message(message) for message in messages]
+            messages_with_success = zip(messages, success)
+
+        return self._handle_processed(messages_with_success)
+
+    def _handle_processed(self, messages_with_success: Iterable[Tuple[Any, bool]]):
+        """
+        Handles the results of processing messages.
+
+        For successful messages, we delete the message ID from the queue, which is
+        equivalent to acknowledging it.
+
+        For failed messages, we change the visibility of the message, in order to
+        keep it un-consumeable for a little while (a form of backoff).
+
+        In each case (delete or change-viz), we batch the API calls to AWS in order
+        to try to avoid getting throttled, with batches of size 10 (the limit). The
+        config (see sqs_env.py) should also retry in the event of exceptions.
+        """
         queue = self.get_queue()
 
-        if self.batching_policy.batching_enabled:
-            return self._process_messages_in_batch(queue, wait_seconds)
-
-        return self._process_messages_individually(queue, wait_seconds)
-
-    def _process_messages_in_batch(self, queue, wait_seconds):
-        messages = self.get_raw_messages(wait_seconds, self.batching_policy.batch_size)
         result = BatchProcessingResult(self.name)
 
-        success = self.process_messages(messages)
+        for subgroup in batcher(messages_with_success, batch_size=10):
+            entries_to_ack = []
+            entries_to_change_viz = []
 
-        for message in messages:
-            result.update_with_message(message, success)
-            if success:
-                entry = {
-                    "Id": message.message_id,
-                    "ReceiptHandle": message.receipt_handle,
-                }
-                queue.delete_messages(Entries=[entry])
-            else:
-                timeout = self.backoff_policy.get_visibility_timeout(message)
-                message.change_visibility(VisibilityTimeout=timeout)
-        return result
+            for m, success in subgroup:
+                result.update_with_message(m, success)
+                if success:
+                    entries_to_ack.append(
+                        {
+                            "Id": m.message_id,
+                            "ReceiptHandle": m.receipt_handle,
+                        }
+                    )
+                else:
+                    entries_to_change_viz.append(
+                        {
+                            "Id": m.message_id,
+                            "ReceiptHandle": m.receipt_handle,
+                            "VisibilityTimeout": self.backoff_policy.get_visibility_timeout(m),
+                        }
+                    )
 
-    def _process_messages_individually(self, queue, wait_seconds):
-        messages = self.get_raw_messages(wait_seconds)
-        result = BatchProcessingResult(self.name)
+            ack_response = queue.delete_messages(Entries=entries_to_ack)
 
-        for message in messages:
-            success = self.process_message(message)
-            result.update_with_message(message, success)
-            if success:
-                entry = {
-                    "Id": message.message_id,
-                    "ReceiptHandle": message.receipt_handle,
-                }
-                queue.delete_messages(Entries=[entry])
-            else:
-                timeout = self.backoff_policy.get_visibility_timeout(message)
-                message.change_visibility(VisibilityTimeout=timeout)
+            if ack_response.get("Failed"):
+                logger.warning(
+                    "Failed to delete processed messages from queue",
+                    extra={"queue": self.name, "failures": ack_response["Failed"]},
+                )
+
+            viz_response = queue.change_message_visibility_batch(
+                Entries=entries_to_change_viz,
+            )
+
+            if viz_response.get("Failed"):
+                logger.warning(
+                    "Failed to change visibility of messages which failed to process",
+                    extra={"queue": self.name, "failures": viz_response["Failed"]},
+                )
+
         return result
 
     def process_message(self, message: Any) -> bool:
@@ -151,15 +181,16 @@ class GenericQueue:
         """
         raise NotImplementedError()
 
-    def get_raw_messages(self, wait_seconds, max_messages=10):
+    def get_raw_messages(self, wait_seconds: int, max_messages: int = 10) -> list[Any]:
         """Return raw messages from the queue, addressed by its name"""
+        queue = self.get_queue()
+
         kwargs = {
             "WaitTimeSeconds": wait_seconds,
             "MaxNumberOfMessages": max_messages if max_messages <= 10 else 10,
             "MessageAttributeNames": ["All"],
             "AttributeNames": ["All"],
         }
-        queue = self.get_queue()
 
         if max_messages <= 10:
             return queue.receive_messages(**kwargs)
@@ -180,16 +211,29 @@ class GenericQueue:
     def drain_queue(self, wait_seconds=0):
         """Delete all messages from the queue without calling purge()."""
         queue = self.get_queue()
+
         deleted_count = 0
         while True:
             messages = self.get_raw_messages(wait_seconds)
             if not messages:
                 break
+
             entries = [
                 {"Id": msg.message_id, "ReceiptHandle": msg.receipt_handle}
                 for msg in messages
             ]
-            queue.delete_messages(Entries=entries)
+
+            ack_response = queue.delete_messages(Entries=entries)
+
+            if ack_response.get("Failed"):
+                logger.warning(
+                    "Failed to delete processed messages from queue",
+                    extra={
+                        "queue": self.name,
+                        "failures": ack_response["Failed"],
+                    },
+                )
+
             deleted_count += len(messages)
         return deleted_count
 

--- a/sqs_workers/queue.py
+++ b/sqs_workers/queue.py
@@ -185,7 +185,7 @@ class GenericQueue:
         """
         raise NotImplementedError()
 
-    def get_raw_messages(self, wait_seconds: int, max_messages: int = 10) -> list[Any]:
+    def get_raw_messages(self, wait_seconds: int, max_messages: int = 10) -> List[Any]:
         """Return raw messages from the queue, addressed by its name"""
         queue = self.get_queue()
 

--- a/sqs_workers/queue.py
+++ b/sqs_workers/queue.py
@@ -94,7 +94,9 @@ class GenericQueue:
         the number of successfully processed messages, and exit
         """
         if self.batching_policy.batching_enabled:
-            messages = self.get_raw_messages(wait_seconds, self.batching_policy.batch_size)
+            messages = self.get_raw_messages(
+                wait_seconds, self.batching_policy.batch_size
+            )
             success = self.process_messages(messages)
             messages_with_success = ((m, success) for m in messages)
         else:
@@ -140,7 +142,9 @@ class GenericQueue:
                         {
                             "Id": m.message_id,
                             "ReceiptHandle": m.receipt_handle,
-                            "VisibilityTimeout": self.backoff_policy.get_visibility_timeout(m),
+                            "VisibilityTimeout": self.backoff_policy.get_visibility_timeout(
+                                m
+                            ),
                         }
                     )
 

--- a/sqs_workers/sqs_env.py
+++ b/sqs_workers/sqs_env.py
@@ -46,6 +46,10 @@ class SQSEnv:
     queue_prefix = attr.ib(default="")
     codec: str = attr.ib(default=codecs.DEFAULT_CONTENT_TYPE)
 
+    # retry settings for internal boto
+    retry_max_attempts: int = attr.ib(default=3)
+    retry_mode: str = attr.ib(default="standard")
+
     # queue-specific settings
     backoff_policy = attr.ib(default=DEFAULT_BACKOFF)
 
@@ -62,7 +66,8 @@ class SQSEnv:
     def __attrs_post_init__(self):
         self.context = self.context_maker()
         # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html
-        retry_config = Config(retries={"max_attempts": 3, "mode": "standard"})
+        retry_dict = {"max_attempts": self.retry_max_attempts, "mode": self.retry_mode}
+        retry_config = Config(retries=retry_dict)
         if not self.sqs_client:
             self.sqs_client = self.session.client("sqs", config=retry_config)
         if not self.sqs_resource:

--- a/sqs_workers/utils.py
+++ b/sqs_workers/utils.py
@@ -1,7 +1,8 @@
 import importlib
 import logging
 from inspect import Signature
-from typing import Any
+from itertools import islice
+from typing import Any, Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -121,3 +122,10 @@ def ensure_string(obj: Any, encoding="utf-8", errors="strict") -> str:
         return obj.decode(encoding, errors)
     else:
         return str(obj)
+
+
+def batcher(iterable, batch_size) -> Iterable[Iterable[Any]]:
+    """Cuts an iterable up into sub-iterables of size batch_size."""
+    iterator = iter(iterable)
+    while batch := list(islice(iterator, batch_size)):
+        yield batch


### PR DESCRIPTION
Does a few things:

* Most importantly -- actually starts looking at the return value of `queue.delete_messages`, and emits a warning if that response contains failures
* Does the same for `queue.change_message_visibility_batch`
* Switches from calling `queue.delete_messages` once per message, to doing it all in one call at the end of processing the batch, which will reduce API calls (up to 10x, depending on batch size) and help with throttling
* Passes a new config to `sqs_resource`, which should (in theory) allow it to auto-retry on when throttles (TBC)
* Updates the silly little in-memory SQS to be remotely similar to SQS itself, with a concept of in-flight messages (I had to do this in order to get the unit tests to work)
* Adds typing in a few places it makes sense (wish we could type the AWS stuff)