### PR TITLE
chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.8
+    rev: v0.11.9
     hooks:
       # Run the linter
       - id: ruff


### PR DESCRIPTION
This is a GitHub workflow (`.github/workflows/pre-commit-update-hooks.yml`) running periodically to update our pre-commit hooks' versions to their latest version.