### PR TITLE
feat: Update SQS message size limit from 256 KB to 1 MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ When batching is enabled:
 
 - tasks are added to SQS by batches of 10, reducing the number of AWS operations
 - it is not possible to get the task `MessageId`, as it is not known until the batch is sent
-- care has to be taken about message size, as SQS limits both the individual message size and the maximum total payload size to 256 kB.
+- care has to be taken about message size, as SQS limits both the individual message size and the maximum total payload size to 1 MB.
 
 ## Batch Reads
 

--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ Localstack tests should perform faster than testing against AWS, and besides, th
 Run [ElasticMQ](https://github.com/softwaremill/elasticmq) and make sure that the SQS endpoint is available by the address localhost:4566:
 
 ```bash
-uv run -p 4566:9324 --rm -it softwaremill/elasticmq-native
+docker run -p 4566:9324 --rm -it softwaremill/elasticmq-native
 ```
 
 Then run

--- a/sqs_workers/queue.py
+++ b/sqs_workers/queue.py
@@ -28,7 +28,7 @@ from sqs_workers.utils import batcher
 
 DEFAULT_MESSAGE_GROUP_ID = "default"
 SEND_BATCH_SIZE = 10
-MAX_MESSAGE_LENGTH = 262144  # 256 KiB
+MAX_MESSAGE_LENGTH = 1048576  # 1 MiB (since Aug 4, 2025)
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable


### PR DESCRIPTION
AWS increased the SQS message size limit from 256 KB to 1 MB on Aug 4, 2025 ([ref](https://aws.amazon.com/about-aws/whats-new/2025/08/amazon-sqs-max-payload-size-1mib/)).
This PR updates the code to reflect this change:

- MAX_MESSAGE_LENGTH constant updated from 262144 to 1048576 bytes
- Documentation updated to reference 1 MB instead of 256 KB
- Tests adjusted to work with the new limit
- Added xfail for localstack tests as ElasticMQ still uses the old limit